### PR TITLE
fix: HubRepository 제네릭 타입 수정

### DIFF
--- a/src/main/java/com/daitda/hubservice/hub/repository/HubRepository.java
+++ b/src/main/java/com/daitda/hubservice/hub/repository/HubRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface HubRepository extends JpaRepository<Hub, Long> {
+public interface HubRepository extends JpaRepository<Hub, UUID> {
 
     Optional<Hub> findByHubIdAndDeletedAtIsNull(UUID hubId);
 


### PR DESCRIPTION
## 🌱 설명

Hub 도메인 기본 구조 작업을 dev 브랜치에서 먼저 진행하는 과정에서,
HubRepository의 제네릭 타입이 엔티티 식별자 타입과 일치하지 않는 부분을 수정했습니다

현재 Hub 엔티티의 PK는 `UUID`인데, Repository가 `Long`으로 선언되어 있어
이를 `UUID`로 정정

참고: Hub 도메인 기본 구조 작업(엔티티 / DTO / 서비스 / 컨트롤러 등)은 앞선 dev 작업에서 반영되었고,
이번 PR은 그 과정에서 발견된 Repository 타입 불일치를 보정


## 📌 관련 이슈

- close #1 

## ✅ 주요 변경 사항

- `HubRepository` 제네릭 타입 수정
  - 변경 전: `JpaRepository<Hub, Long>`
  - 변경 후: `JpaRepository<Hub, UUID>`
- Hub 엔티티 PK 타입과 Repository 선언 일치화


## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- Hub 도메인 기본 구조 구현은 dev 브랜치에서 먼저 작업되었습니다
- 이번 PR은 그 작업 중 발견된 Repository 식별자 타입 오류를 수정하기 위한 보완 PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Hub 식별자 형식이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->