### PR TITLE
chore: hub-service eureka 및 config server 연동 설정 적용

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
-PORT=8082
-EUREKA_SERVER_URL=http://localhost:8761/eureka
+SPRING_PROFILES_ACTIVE=local
 
-DB_URL=jdbc:postgresql://localhost:5432/hub_db
-DB_USERNAME=postgres
 DB_PASSWORD=
+POSTGRES_HOST=localhost
+
+EUREKA_HOST=localhost
+ZIPKIN_HOST=localhost
+
+GITHUB_USERNAME=
+GITHUB_TOKEN=
 
 NAVER_MAP_CLIENT_ID=
 NAVER_MAP_CLIENT_SECRET=

--- a/build.gradle
+++ b/build.gradle
@@ -41,15 +41,20 @@ dependencies {
 //	DB 연결 후 사용
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
 //	eureka server 등록할 때 사용 권장
-//	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     implementation 'com.fhsh.daitda:common:0.0.1-SNAPSHOT'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-    implementation 'com.fhsh.daitda:common:0.0.1-SNAPSHOT'
+    testImplementation 'com.h2database:h2'
+    implementation 'com.fhsh.daitda:common:0.1.1-SNAPSHOT'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    testImplementation 'com.h2database:h2'
     implementation 'com.fhsh.daitda:common:0.1.1-SNAPSHOT'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 //	DB 연결 후 사용
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 //	eureka server 등록할 때 사용 권장
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/src/main/java/com/fhsh/daitda/hubservice/HubServiceApplication.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/HubServiceApplication.java
@@ -2,10 +2,14 @@ package com.fhsh.daitda.hubservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableDiscoveryClient
+@EnableFeignClients
 public class HubServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -7,7 +7,3 @@ logging:
     org.hibernate.SQL: DEBUG
     com.fhsh.daitda: DEBUG
 
-naver:
-  map:
-    client-id: ${NAVER_MAP_CLIENT_ID:}
-    client-secret: ${NAVER_MAP_CLIENT_SECRET:}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    password: ${DB_PASSWORD}
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    com.fhsh.daitda: DEBUG
+
+naver:
+  map:
+    client-id: ${NAVER_MAP_CLIENT_ID:}
+    client-secret: ${NAVER_MAP_CLIENT_SECRET:}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,32 +1,13 @@
 spring:
   application:
     name: hub-service
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
+  cloud:
+    config:
+      discovery:
+        enabled: true
+        service-id: config-server
   config:
-    import: "optional:file:./.env[.properties]"
-
-  datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: org.postgresql.Driver
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-
-server:
-  port: ${PORT:8082}
-
-eureka:
-  client:
-    service-url:
-      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka}
-
-naver:
-  map:
-    client-id: ${NAVER_MAP_CLIENT_ID:}
-    client-secret: ${NAVER_MAP_CLIENT_SECRET:}
+    import:
+      - "configserver:"


### PR DESCRIPTION
## 🌱 설명

hub-service가 팀 공통 인프라 환경에서 실행될 수 있도록 Config Server, Eureka, Docker Postgres 연동을 적용
기존 단독 실행 기준 설정을 정리하고, 중앙 설정을 받아 서비스가 정상 기동 및 Eureka 등록되도록 수정

## 📌 관련 이슈

- close #10 

## ✅ 주요 변경 사항

- hub-service에 Config Server, Eureka Client, OpenFeign 관련 의존성 및 설정을 추가
- application.yml / application-local.yml 구성을 팀 공통 설정 방식에 맞게 정리
- hub-service가 정상 기동되고 Eureka에 등록되는 것을 확인

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- Eureka 대시보드에서 HUB-SERVICE가 정상 등록되는 것까지 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 서비스 디스커버리 및 Feign 클라이언트 활성화로 마이크로서비스 통합 지원
  * Spring Cloud Config 연동으로 중앙화된 환경설정 도입
  * 프로파일 기반 환경 지원 추가(기본값: local) 및 로컬 설정 파일 추가
  * 액추에이터·관찰성 관련 의존성 활성화로 운영 모니터링 강화
  * 호스트 기반 DB·Eureka·Zipkin 설정으로 환경변수 정비 및 GitHub 자격증명 자리표시자 추가
  * 디버깅용 로깅 레벨 조정 및 설정 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->