### PR TITLE
refactor: common error code 인터페이스 구조에 맞게 예외 코드 분리

### DIFF
--- a/src/main/java/com/fhsh/daitda/hubservice/hub/application/service/HubService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hub/application/service/HubService.java
@@ -1,12 +1,12 @@
 package com.fhsh.daitda.hubservice.hub.application.service;
 
 import com.fhsh.daitda.exception.BusinessException;
-import com.fhsh.daitda.exception.ErrorCode;
 import com.fhsh.daitda.hubservice.hub.application.command.CreateHubCommand;
 import com.fhsh.daitda.hubservice.hub.application.command.UpdateHubCommand;
 import com.fhsh.daitda.hubservice.hub.application.result.FindHubResult;
 import com.fhsh.daitda.hubservice.hub.application.result.ListHubResult;
 import com.fhsh.daitda.hubservice.hub.domain.entity.Hub;
+import com.fhsh.daitda.hubservice.hub.domain.exception.HubErrorCode;
 import com.fhsh.daitda.hubservice.hub.domain.repository.HubRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,13 +72,8 @@ public class HubService {
         hub.softDelete(deletedBy);
     }
 
-
-    /*
-    * common ErrorCode에서 404에 가장 가까운 건 INVALID_PATH라 임시 사용
-    * 나중에 RESOURCE_NOT_FOUND류가 common에 추가?
-    */
     private Hub findActiveHub(UUID hubId) {
         return hubRepository.findByHubIdAndDeletedAtIsNull(hubId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_PATH));
+                .orElseThrow(() -> new BusinessException(HubErrorCode.HUB_NOT_FOUND));
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hub/domain/exception/HubErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hub/domain/exception/HubErrorCode.java
@@ -1,0 +1,19 @@
+package com.fhsh.daitda.hubservice.hub.domain.exception;
+
+import com.fhsh.daitda.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum HubErrorCode implements ErrorCode {
+
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "허브를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String description;
+
+    HubErrorCode(HttpStatus status, String description) {
+        this.status = status;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryService.java
@@ -1,7 +1,6 @@
 package com.fhsh.daitda.hubservice.hubinventory.application.service;
 
 import com.fhsh.daitda.exception.BusinessException;
-import com.fhsh.daitda.exception.ErrorCode;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.CreateHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.RestoreHubInventoryCommand;
@@ -9,6 +8,7 @@ import com.fhsh.daitda.hubservice.hubinventory.application.command.UpdateHubInve
 import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.ListHubInventoryResult;
 import com.fhsh.daitda.hubservice.hubinventory.domain.entity.HubInventory;
+import com.fhsh.daitda.hubservice.hubinventory.domain.exception.HubInventoryErrorCode;
 import com.fhsh.daitda.hubservice.hubinventory.domain.repository.HubInventoryRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -44,7 +44,7 @@ public class HubInventoryService {
             HubInventory savedHubInventory = hubInventoryRepository.saveAndFlush(hubInventory);
             return FindHubInventoryResult.from(savedHubInventory);
         } catch (DataIntegrityViolationException e) {
-            throw new BusinessException(ErrorCode.CONFLICT);
+            throw new BusinessException(HubInventoryErrorCode.HUB_INVENTORY_CONFLICT);
         }
     }
 
@@ -74,11 +74,7 @@ public class HubInventoryService {
     public FindHubInventoryResult searchHubInventory(UUID hubId, UUID companyId, UUID productId) {
         HubInventory hubInventory = hubInventoryRepository
                 .findByHubIdAndCompanyIdAndProductIdAndDeletedAtIsNull(hubId, companyId, productId)
-                /*
-                 * common ErrorCode에서 404에 가장 가까운 건 INVALID_PATH라 임시 사용
-                 * 나중에 RESOURCE_NOT_FOUND류가 common에 추가?
-                 */
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_PATH));
+                .orElseThrow(() -> new BusinessException(HubInventoryErrorCode.HUB_INVENTORY_NOT_FOUND));
 
         return FindHubInventoryResult.from(hubInventory);
     }
@@ -125,17 +121,13 @@ public class HubInventoryService {
         boolean exists = hubInventoryRepository.existsByHubIdAndCompanyIdAndProductIdAndDeletedAtIsNull(hubId, companyId, productId);
 
         if (exists) {
-            throw new BusinessException(ErrorCode.CONFLICT);
+            throw new BusinessException(HubInventoryErrorCode.HUB_INVENTORY_CONFLICT);
         }
     }
 
     // 삭제 안 된 재고 row만 찾기
     private HubInventory findActiveHubInventory(UUID hubInventoryId) {
         return hubInventoryRepository.findByHubInventoryIdAndDeletedAtIsNull(hubInventoryId)
-                /*
-                 * common ErrorCode에서 404에 가장 가까운 건 INVALID_PATH라 임시 사용(not found 에러x)
-                 * 나중에 RESOURCE_NOT_FOUND류가 common에 추가?
-                 */
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_PATH));
+                .orElseThrow(() -> new BusinessException(HubInventoryErrorCode.HUB_INVENTORY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/domain/exception/HubInventoryErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/domain/exception/HubInventoryErrorCode.java
@@ -1,0 +1,20 @@
+package com.fhsh.daitda.hubservice.hubinventory.domain.exception;
+
+import com.fhsh.daitda.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum HubInventoryErrorCode implements ErrorCode {
+
+    HUB_INVENTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "허브 재고를 찾을 수 없습니다."),
+    HUB_INVENTORY_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 허브 재고입니다.");
+
+    private final HttpStatus status;
+    private final String description;
+
+    HubInventoryErrorCode(HttpStatus status, String description) {
+        this.status = status;
+        this.description = description;
+    }
+}

--- a/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryServiceTest.java
@@ -1,11 +1,11 @@
 package com.fhsh.daitda.hubservice.hubinventory.application.service;
 
 import com.fhsh.daitda.exception.BusinessException;
-import com.fhsh.daitda.exception.ErrorCode;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.CreateHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
 import com.fhsh.daitda.hubservice.hubinventory.domain.entity.HubInventory;
+import com.fhsh.daitda.hubservice.hubinventory.domain.exception.HubInventoryErrorCode;
 import com.fhsh.daitda.hubservice.hubinventory.domain.repository.HubInventoryRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -96,7 +96,7 @@ public class HubInventoryServiceTest {
         assertThatThrownBy(() -> hubInventoryService.createHubInventory(command, USER_ID))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.CONFLICT);
+                .isEqualTo(HubInventoryErrorCode.HUB_INVENTORY_CONFLICT);
 
         verify(hubInventoryRepository, never()).saveAndFlush(any(HubInventory.class));
     }
@@ -142,7 +142,7 @@ public class HubInventoryServiceTest {
         assertThatThrownBy(() -> hubInventoryService.createHubInventory(command, USER_ID))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.CONFLICT);
+                .isEqualTo(HubInventoryErrorCode.HUB_INVENTORY_CONFLICT);
     }
 
     private HubInventory 생성된재고(int quantity) {


### PR DESCRIPTION
## 🌱 설명

common 모듈 0.1.1-SNAPSHOT 업데이트에 맞춰 hub-service의 예외 처리 구조를 수정

기존에는 공통 ErrorCode enum을 직접 참조했지만, 이번 common 변경으로 ErrorCode가 interface로 변경되어
hub / hubinventory 도메인별 ErrorCode를 분리하고 관련 서비스 및 테스트 코드도 함께 정리


## 📌 관련 이슈

- close #13 

## ✅ 주요 변경 사항

- hub, hubinventory 도메인별 ErrorCode를 추가하고 기존 공통 ErrorCode 직접 참조 코드를 수정
- BusinessException 사용부와 관련 테스트 코드를 도메인별 ErrorCode 기준으로 정리

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- common 모듈 변경 사항 반영이 목적


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 허브를 찾을 수 없을 때 더 명확한 오류 메시지 표시
  * 허브 재고 조회 실패 시 정확한 오류 코드 반환 (미발견/중복)
  * 오류 응답의 HTTP 상태 코드 및 메시지 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->