### PR TITLE
[refactor] hub-service 테스트용 설정 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,4 +67,5 @@ dependencyManagement {
 
 tasks.named('test') {
     useJUnitPlatform()
+    systemProperty 'spring.config.name', 'application-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.fhsh.daitda:common:0.1.1-SNAPSHOT'

--- a/src/test/java/com/fhsh/daitda/hubservice/HubServiceApplicationTests.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/HubServiceApplicationTests.java
@@ -3,14 +3,7 @@ package com.fhsh.daitda.hubservice;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(
-        properties = {
-                "spring.config.name=application-test",
-                "spring.cloud.config.enabled=false",
-                "spring.cloud.config.import-check.enabled=false",
-                "eureka.client.enabled=false"
-        }
-)
+@SpringBootTest
 class HubServiceApplicationTests {
 
     @Test

--- a/src/test/java/com/fhsh/daitda/hubservice/HubServiceApplicationTests.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/HubServiceApplicationTests.java
@@ -3,7 +3,14 @@ package com.fhsh.daitda.hubservice;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(
+        properties = {
+                "spring.config.name=application-test",
+                "spring.cloud.config.enabled=false",
+                "spring.cloud.config.import-check.enabled=false",
+                "eureka.client.enabled=false"
+        }
+)
 class HubServiceApplicationTests {
 
     @Test

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:hubtest;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE;INIT=CREATE SCHEMA IF NOT EXISTS hub_service
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        default_schema: hub_service
+        dialect: org.hibernate.dialect.H2Dialect
+
+eureka:
+  client:
+    enabled: false

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,4 +1,10 @@
 spring:
+  cloud:
+    config:
+      enabled: false
+      import-check:
+        enabled: false
+
   datasource:
     url: jdbc:h2:mem:hubtest;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE;INIT=CREATE SCHEMA IF NOT EXISTS hub_service
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
## 🌱 설명

hub-service 테스트 실행 시 Config Server, Eureka, PostgreSQL 같은 외부 인프라에 의존하지 않도록 테스트용 설정을 분리했습니다.

기존에는 `./gradlew test` 실행 시에도 실제 Config Server 연결을 시도하면서 테스트가 실패할 수 있었고,
이를 해결하기 위해 테스트 전용 프로필 및 설정 파일을 분리해 독립적으로 실행되도록 정리했습니다.
## 📌 관련 이슈

- close #15 

## ✅ 주요 변경 사항

- `application-test.yml` 등 테스트 전용 설정을 분리
- 테스트 환경에서 Config Server 및 Eureka 연결을 비활성화하도록 설정
- 테스트 실행 시 사용할 DB 설정을 분리해 외부 인프라 의존성을 제거


## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- 테스트가 외부 설정 서버에 의존하지 않도록 분리하는 것이 목적이며
- `contextLoads()`를 포함한 기본 테스트가 로컬/CI 환경에서 안정적으로 수행되도록 정리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 테스트
- 테스트 환경을 위한 인메모리 데이터베이스 구성을 추가했습니다.

## 기타
- 테스트 실행 시 필요한 데이터베이스 의존성을 추가하고 테스트 설정을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->