### PR TITLE
[feature] integrate gateway authentication into hub-service

### DIFF
--- a/src/main/java/com/fhsh/daitda/common/config/security/SecurityHeaderConstants.java
+++ b/src/main/java/com/fhsh/daitda/common/config/security/SecurityHeaderConstants.java
@@ -1,0 +1,12 @@
+package com.fhsh.daitda.common.config.security;
+
+public class SecurityHeaderConstants {
+
+    public static final String USER_ID = "X-User-Id";
+    public static final String USER_EMAIL = "X-User-Email";
+    public static final String USER_ROLE = "X-User-Role";
+
+    private SecurityHeaderConstants() {
+        throw new IllegalArgumentException("Utility class");
+    }
+}

--- a/src/main/java/com/fhsh/daitda/common/enums/UserRole.java
+++ b/src/main/java/com/fhsh/daitda/common/enums/UserRole.java
@@ -1,0 +1,29 @@
+package com.fhsh.daitda.common.enums;
+
+import java.util.Arrays;
+
+public enum UserRole {
+    ADMIN,
+    HUB_ADMIN,
+    DELIVERY,
+    COMPANY;
+
+    public static UserRole from(String role) {
+        if (role == null || role.isBlank()) {
+            throw new IllegalArgumentException("사용자 권한 헤더가 존재하지 않습니다.");
+        }
+
+        return Arrays.stream(values())
+                .filter(userRole -> userRole.name().equalsIgnoreCase(role))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 사용자 권한입니다."));
+    }
+
+    public boolean isAdmin() {
+        return this == ADMIN;
+    }
+
+    public boolean isHubAdmin() {
+        return this == HUB_ADMIN;
+    }
+}

--- a/src/main/java/com/fhsh/daitda/common/enums/UserRole.java
+++ b/src/main/java/com/fhsh/daitda/common/enums/UserRole.java
@@ -1,5 +1,7 @@
 package com.fhsh.daitda.common.enums;
 
+import com.fhsh.daitda.common.exception.InvalidAuthenticationHeaderException;
+
 import java.util.Arrays;
 
 public enum UserRole {
@@ -10,13 +12,13 @@ public enum UserRole {
 
     public static UserRole from(String role) {
         if (role == null || role.isBlank()) {
-            throw new IllegalArgumentException("사용자 권한 헤더가 존재하지 않습니다.");
+            throw new InvalidAuthenticationHeaderException("사용자 권한 헤더가 존재하지 않습니다.");
         }
 
         return Arrays.stream(values())
                 .filter(userRole -> userRole.name().equalsIgnoreCase(role))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 사용자 권한입니다."));
+                .orElseThrow(() -> new InvalidAuthenticationHeaderException("지원하지 않는 사용자 권한입니다."));
     }
 
     public boolean isAdmin() {

--- a/src/main/java/com/fhsh/daitda/common/exception/InvalidAuthenticationHeaderException.java
+++ b/src/main/java/com/fhsh/daitda/common/exception/InvalidAuthenticationHeaderException.java
@@ -1,0 +1,12 @@
+package com.fhsh.daitda.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class InvalidAuthenticationHeaderException extends RuntimeException {
+
+    public InvalidAuthenticationHeaderException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/fhsh/daitda/common/model/AuthenticatedUser.java
+++ b/src/main/java/com/fhsh/daitda/common/model/AuthenticatedUser.java
@@ -1,6 +1,7 @@
 package com.fhsh.daitda.common.model;
 
 import com.fhsh.daitda.common.enums.UserRole;
+import com.fhsh.daitda.common.exception.InvalidAuthenticationHeaderException;
 
 public record AuthenticatedUser(
         String userId,
@@ -9,7 +10,7 @@ public record AuthenticatedUser(
 ) {
     public static AuthenticatedUser fromHeaders(String userId, String email, String role) {
         if (userId == null || userId.isBlank()) {
-            throw new IllegalArgumentException("사용자 식별 헤더가 존재하지 않습니다.");
+            throw new InvalidAuthenticationHeaderException("사용자 식별 헤더가 존재하지 않습니다.");
         }
 
         return new AuthenticatedUser(

--- a/src/main/java/com/fhsh/daitda/common/model/AuthenticatedUser.java
+++ b/src/main/java/com/fhsh/daitda/common/model/AuthenticatedUser.java
@@ -1,0 +1,29 @@
+package com.fhsh.daitda.common.model;
+
+import com.fhsh.daitda.common.enums.UserRole;
+
+public record AuthenticatedUser(
+        String userId,
+        String email,
+        UserRole role
+) {
+    public static AuthenticatedUser fromHeaders(String userId, String email, String role) {
+        if (userId == null || userId.isBlank()) {
+            throw new IllegalArgumentException("사용자 식별 헤더가 존재하지 않습니다.");
+        }
+
+        return new AuthenticatedUser(
+                userId,
+                email != null ? email : "",
+                UserRole.from(role)
+        );
+    }
+
+    public boolean isAdmin() {
+        return role.isAdmin();
+    }
+
+    public boolean isHubAdmin() {
+        return role.isHubAdmin();
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/external/HubController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/external/HubController.java
@@ -35,9 +35,9 @@ public class HubController {
     @PostMapping
     public ResponseEntity<HubResponse> createHub(
             @Valid @RequestBody HubCreateRequest request,
-            @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
-            @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
-            @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role
+            @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+            @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+            @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role
     ) {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -77,9 +77,9 @@ public class HubController {
     @PatchMapping("/{hubId}")
     public ResponseEntity<HubResponse> updateHub(@PathVariable UUID hubId,
                                                  @Valid @RequestBody HubUpdateRequest request,
-                                                 @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
-                                                 @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
-                                                 @RequestHeader(value = SecurityHeaderConstants.USER_ROLE)String role)
+                                                 @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                                 @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                 @RequestHeader(SecurityHeaderConstants.USER_ROLE)String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -99,9 +99,9 @@ public class HubController {
 
     @DeleteMapping("/{hubId}")
     public ResponseEntity<Void> deleteHub(@PathVariable UUID hubId,
-                                          @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
-                                          @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
-                                          @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
+                                          @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                          @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                          @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 

--- a/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/external/HubController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/external/HubController.java
@@ -1,5 +1,7 @@
-package com.fhsh.daitda.hubservice.hub.presentation.controller;
+package com.fhsh.daitda.hubservice.hub.presentation.controller.external;
 
+import com.fhsh.daitda.common.config.security.SecurityHeaderConstants;
+import com.fhsh.daitda.common.model.AuthenticatedUser;
 import com.fhsh.daitda.hubservice.hub.application.command.CreateHubCommand;
 import com.fhsh.daitda.hubservice.hub.application.command.UpdateHubCommand;
 import com.fhsh.daitda.hubservice.hub.application.result.FindHubResult;
@@ -26,8 +28,20 @@ public class HubController {
         this.hubService = hubService;
     }
 
+    /**
+     * 허브를 생성
+     * 외부 요청은 Gateway를 통해 진입하므로 사용자 헤더를 받아 createdBy에 반영
+     */
     @PostMapping
-    public ResponseEntity<HubResponse> createHub(@Valid @RequestBody HubCreateRequest request) {
+    public ResponseEntity<HubResponse> createHub(
+            @Valid @RequestBody HubCreateRequest request,
+            @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
+            @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+            @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role
+    ) {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+
+
         CreateHubCommand command = CreateHubCommand.builder()
                 .hubName(request.getHubName())
                 .hubAddress(request.getHubAddress())
@@ -36,7 +50,7 @@ public class HubController {
                 .isCentral(request.getIsCentral())
                 .build();
 
-        FindHubResult result = hubService.createHub(command, null);
+        FindHubResult result = hubService.createHub(command, authenticatedUser.userId());
         HubResponse response = HubResponse.from(result);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -62,7 +76,13 @@ public class HubController {
 
     @PatchMapping("/{hubId}")
     public ResponseEntity<HubResponse> updateHub(@PathVariable UUID hubId,
-                                                 @Valid @RequestBody HubUpdateRequest request) {
+                                                 @Valid @RequestBody HubUpdateRequest request,
+                                                 @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
+                                                 @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                 @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false)String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+
         UpdateHubCommand command = UpdateHubCommand.builder()
                 .hubName(request.getHubName())
                 .hubAddress(request.getHubAddress())
@@ -71,15 +91,21 @@ public class HubController {
                 .isCentral(request.getIsCentral())
                 .build();
 
-        FindHubResult result = hubService.updateHub(hubId, command, null);
+        FindHubResult result = hubService.updateHub(hubId, command, authenticatedUser.userId());
         HubResponse response = HubResponse.from(result);
 
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{hubId}")
-    public ResponseEntity<Void> deleteHub(@PathVariable UUID hubId) {
-        hubService.deleteHub(hubId, null);
+    public ResponseEntity<Void> deleteHub(@PathVariable UUID hubId,
+                                          @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
+                                          @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                          @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+
+        hubService.deleteHub(hubId, authenticatedUser.userId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/external/HubController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/external/HubController.java
@@ -35,9 +35,9 @@ public class HubController {
     @PostMapping
     public ResponseEntity<HubResponse> createHub(
             @Valid @RequestBody HubCreateRequest request,
-            @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
-            @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
-            @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role
+            @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
+            @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
+            @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role
     ) {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -77,9 +77,9 @@ public class HubController {
     @PatchMapping("/{hubId}")
     public ResponseEntity<HubResponse> updateHub(@PathVariable UUID hubId,
                                                  @Valid @RequestBody HubUpdateRequest request,
-                                                 @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
-                                                 @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
-                                                 @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false)String role)
+                                                 @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
+                                                 @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
+                                                 @RequestHeader(value = SecurityHeaderConstants.USER_ROLE)String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -99,9 +99,9 @@ public class HubController {
 
     @DeleteMapping("/{hubId}")
     public ResponseEntity<Void> deleteHub(@PathVariable UUID hubId,
-                                          @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
-                                          @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
-                                          @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+                                          @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
+                                          @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
+                                          @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/external/HubInventoryController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/external/HubInventoryController.java
@@ -31,9 +31,9 @@ public class HubInventoryController {
     // 재고 생성
     @PostMapping
     public ResponseEntity<FindHubInventoryResponse> createHubInventory(@Valid @RequestBody CreateHubInventoryRequest request,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -85,9 +85,9 @@ public class HubInventoryController {
     @PatchMapping("/{hubInventoryId}")
     public ResponseEntity<FindHubInventoryResponse> updateHubInventory(@PathVariable UUID hubInventoryId,
                                                                        @Valid @RequestBody UpdateHubInventoryRequest request,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -104,9 +104,9 @@ public class HubInventoryController {
     // 재고 논리 삭제
     @DeleteMapping("/{hubInventoryId}")
     public ResponseEntity<Void> deleteHubInventory(@PathVariable UUID hubInventoryId,
-                                                   @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
-                                                   @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
-                                                   @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+                                                   @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
+                                                   @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
+                                                   @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
         hubInventoryService.deleteHubInventory(hubInventoryId, authenticatedUser.userId());

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/external/HubInventoryController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/external/HubInventoryController.java
@@ -31,9 +31,9 @@ public class HubInventoryController {
     // 재고 생성
     @PostMapping
     public ResponseEntity<FindHubInventoryResponse> createHubInventory(@Valid @RequestBody CreateHubInventoryRequest request,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
+                                                                       @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                                       @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -85,9 +85,9 @@ public class HubInventoryController {
     @PatchMapping("/{hubInventoryId}")
     public ResponseEntity<FindHubInventoryResponse> updateHubInventory(@PathVariable UUID hubInventoryId,
                                                                        @Valid @RequestBody UpdateHubInventoryRequest request,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
-                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
+                                                                       @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                                       @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -104,9 +104,9 @@ public class HubInventoryController {
     // 재고 논리 삭제
     @DeleteMapping("/{hubInventoryId}")
     public ResponseEntity<Void> deleteHubInventory(@PathVariable UUID hubInventoryId,
-                                                   @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
-                                                   @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
-                                                   @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
+                                                   @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                                   @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                   @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
         hubInventoryService.deleteHubInventory(hubInventoryId, authenticatedUser.userId());

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/external/HubInventoryController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/external/HubInventoryController.java
@@ -1,5 +1,7 @@
-package com.fhsh.daitda.hubservice.hubinventory.presentation.controller;
+package com.fhsh.daitda.hubservice.hubinventory.presentation.controller.external;
 
+import com.fhsh.daitda.common.config.security.SecurityHeaderConstants;
+import com.fhsh.daitda.common.model.AuthenticatedUser;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.CreateHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.UpdateHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
@@ -28,7 +30,12 @@ public class HubInventoryController {
 
     // 재고 생성
     @PostMapping
-    public ResponseEntity<FindHubInventoryResponse> createHubInventory(@Valid @RequestBody CreateHubInventoryRequest request) {
+    public ResponseEntity<FindHubInventoryResponse> createHubInventory(@Valid @RequestBody CreateHubInventoryRequest request,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
         CreateHubInventoryCommand command = CreateHubInventoryCommand.builder()
                 .hubId(request.getHubId())
@@ -37,7 +44,7 @@ public class HubInventoryController {
                 .quantity(request.getQuantity())
                 .build();
 
-        FindHubInventoryResult result = hubInventoryService.createHubInventory(command, null);
+        FindHubInventoryResult result = hubInventoryService.createHubInventory(command, authenticatedUser.userId());
         FindHubInventoryResponse response = FindHubInventoryResponse.from(result);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -77,12 +84,18 @@ public class HubInventoryController {
     // 재고 수량 직접 수정
     @PatchMapping("/{hubInventoryId}")
     public ResponseEntity<FindHubInventoryResponse> updateHubInventory(@PathVariable UUID hubInventoryId,
-                                                                       @Valid @RequestBody UpdateHubInventoryRequest request) {
+                                                                       @Valid @RequestBody UpdateHubInventoryRequest request,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+
         UpdateHubInventoryCommand command = UpdateHubInventoryCommand.builder()
                 .quantity(request.getQuantity())
                 .build();
 
-        FindHubInventoryResult result = hubInventoryService.updateHubInventory(hubInventoryId, command, null);
+        FindHubInventoryResult result = hubInventoryService.updateHubInventory(hubInventoryId, command, authenticatedUser.userId());
         FindHubInventoryResponse response = FindHubInventoryResponse.from(result);
 
         return ResponseEntity.ok(response);
@@ -90,8 +103,13 @@ public class HubInventoryController {
 
     // 재고 논리 삭제
     @DeleteMapping("/{hubInventoryId}")
-    public ResponseEntity<Void> deleteHubInventory(@PathVariable UUID hubInventoryId) {
-        hubInventoryService.deleteHubInventory(hubInventoryId, null);
+    public ResponseEntity<Void> deleteHubInventory(@PathVariable UUID hubInventoryId,
+                                                   @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
+                                                   @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                   @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        hubInventoryService.deleteHubInventory(hubInventoryId, authenticatedUser.userId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
@@ -1,4 +1,4 @@
-package com.fhsh.daitda.hubservice.hubinventory.presentation.controller;
+package com.fhsh.daitda.hubservice.hubinventory.presentation.controller.internal;
 
 import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.RestoreHubInventoryCommand;

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/external/HubRouteController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/external/HubRouteController.java
@@ -30,9 +30,9 @@ public class HubRouteController {
      */
     @PostMapping
     public FindHubRouteResponse createHubRoute(@Valid @RequestBody CreateHubRouteRequest request,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -79,9 +79,9 @@ public class HubRouteController {
     @PatchMapping("/{hubRouteId}")
     public FindHubRouteResponse updateHubRoute(@PathVariable UUID hubRouteId,
                                                @Valid @RequestBody UpdateHubRouteRequest request,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -95,9 +95,9 @@ public class HubRouteController {
      */
     @DeleteMapping("/{hubRouteId}")
     public void deleteHubRoute(@PathVariable UUID hubRouteId,
-                               @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
-                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
-                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+                               @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
+                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
+                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/external/HubRouteController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/external/HubRouteController.java
@@ -1,5 +1,7 @@
 package com.fhsh.daitda.hubservice.hubroute.presentation.controller.external;
 
+import com.fhsh.daitda.common.config.security.SecurityHeaderConstants;
+import com.fhsh.daitda.common.model.AuthenticatedUser;
 import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.application.result.ListHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.application.service.HubRouteService;
@@ -27,8 +29,14 @@ public class HubRouteController {
      * 출발 허브와 도착 허브 기준의 허브 경로 생성
      */
     @PostMapping
-    public FindHubRouteResponse createHubRoute(@Valid @RequestBody CreateHubRouteRequest request) {
-        FindHubRouteResult result = hubRouteService.createHubRoute(request.toCommand(), null);
+    public FindHubRouteResponse createHubRoute(@Valid @RequestBody CreateHubRouteRequest request,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+
+        FindHubRouteResult result = hubRouteService.createHubRoute(request.toCommand(), authenticatedUser.userId());
         return FindHubRouteResponse.from(result);
     }
 
@@ -69,11 +77,15 @@ public class HubRouteController {
      * 허브 경로의 소요 시간과 이동 거리 수정
      */
     @PatchMapping("/{hubRouteId}")
-    public FindHubRouteResponse updateHubRoute(
-            @PathVariable UUID hubRouteId,
-            @Valid @RequestBody UpdateHubRouteRequest request
-    ) {
-        FindHubRouteResult result = hubRouteService.updateHubRoute(hubRouteId, request.toCommand(), null);
+    public FindHubRouteResponse updateHubRoute(@PathVariable UUID hubRouteId,
+                                               @Valid @RequestBody UpdateHubRouteRequest request,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+
+        FindHubRouteResult result = hubRouteService.updateHubRoute(hubRouteId, request.toCommand(), authenticatedUser.userId());
         return FindHubRouteResponse.from(result);
     }
 
@@ -82,7 +94,13 @@ public class HubRouteController {
      * 지금은 삭제 성공 여부만 의미가 있어 별도 응답 본문 없이 void로 처리
      */
     @DeleteMapping("/{hubRouteId}")
-    public void deleteHubRoute(@PathVariable UUID hubRouteId) {
-        hubRouteService.deleteHubRoute(hubRouteId, null);
+    public void deleteHubRoute(@PathVariable UUID hubRouteId,
+                               @RequestHeader(value = SecurityHeaderConstants.USER_ID, required = false) String userId,
+                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE, required = false) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+
+        hubRouteService.deleteHubRoute(hubRouteId, authenticatedUser.userId());
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/external/HubRouteController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/external/HubRouteController.java
@@ -30,9 +30,9 @@ public class HubRouteController {
      */
     @PostMapping
     public FindHubRouteResponse createHubRoute(@Valid @RequestBody CreateHubRouteRequest request,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
+                                               @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                               @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -79,9 +79,9 @@ public class HubRouteController {
     @PatchMapping("/{hubRouteId}")
     public FindHubRouteResponse updateHubRoute(@PathVariable UUID hubRouteId,
                                                @Valid @RequestBody UpdateHubRouteRequest request,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
-                                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
+                                               @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                               @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 
@@ -95,9 +95,9 @@ public class HubRouteController {
      */
     @DeleteMapping("/{hubRouteId}")
     public void deleteHubRoute(@PathVariable UUID hubRouteId,
-                               @RequestHeader(value = SecurityHeaderConstants.USER_ID) String userId,
-                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL) String email,
-                               @RequestHeader(value = SecurityHeaderConstants.USER_ROLE) String role)
+                               @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                               @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
 


### PR DESCRIPTION
## 🌱 설명

Gateway에서 전달하는 사용자 인증 헤더를 hub-service의 external API에서 수신하도록 반영

기존에 `createdBy`, `updatedBy`, `deletedBy` 등에 `null`을 전달하던 부분을 사용자 식별값으로 연결
`/internal/**` 경로는 Gateway를 거치지 않는 정책에 맞게 기존 방식 그대로 유지

## 📌 관련 이슈

- close #18 

## ✅ 주요 변경 사항

- `AuthenticatedUser` 추가
- `UserRole` 추가
- `SecurityHeaderConstants` 추가
- external `HubController`에 Gateway 사용자 헤더 반영
- external `HubInventoryController`에 Gateway 사용자 헤더 반영
- external `HubRouteController`에 Gateway 사용자 헤더 반영
- create / update / delete 흐름에서 `null` 대신 `authenticatedUser.userId()` 전달
- `HubInventoryInternalController` internal 패키지로 이동
- internal API는 Gateway 인증 헤더를 사용하지 않도록 유지

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- 외부 요청은 Gateway를 통해 진입하고, `X-User-Id`, `X-User-Email`, `X-User-Role` 헤더를 기반으로 사용자 정보를 처리
- `/internal/**` 경로는 내부 서비스 간 통신 전용이므로 이번 PR에서 인증 헤더 처리 대상에서 제외
- 이번 PR은 **헤더 수신 및 audit 값 반영**에 집중했고, 세부 권한 제어는 후속 작업에서 정리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - API에서 인증 헤더(X-User-Id, X-User-Email, X-User-Role) 입력 지원 추가
  - 사용자 역할 타입과 인증된 사용자 표현 도입

- **기능 개선**
  - 생성/수정/삭제 요청에 호출자 정보 전달으로 권한 검증 강화
  - 역할 문자열 검증 및 관리자/HUB 관리자 판별 기능 추가
  - 유효하지 않은 인증 헤더에 대해 401 응답 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->