### PR TITLE
[feature] add authorization policy to hub service external apis

### DIFF
--- a/src/main/java/com/fhsh/daitda/common/config/security/SecurityHeaderConstants.java
+++ b/src/main/java/com/fhsh/daitda/common/config/security/SecurityHeaderConstants.java
@@ -1,12 +1,12 @@
 package com.fhsh.daitda.common.config.security;
 
-public class SecurityHeaderConstants {
+public final class SecurityHeaderConstants {
 
     public static final String USER_ID = "X-User-Id";
     public static final String USER_EMAIL = "X-User-Email";
     public static final String USER_ROLE = "X-User-Role";
 
     private SecurityHeaderConstants() {
-        throw new IllegalArgumentException("Utility class");
+        throw new IllegalStateException("Utility class");
     }
 }

--- a/src/main/java/com/fhsh/daitda/common/enums/UserRole.java
+++ b/src/main/java/com/fhsh/daitda/common/enums/UserRole.java
@@ -28,4 +28,12 @@ public enum UserRole {
     public boolean isHubAdmin() {
         return this == HUB_ADMIN;
     }
+
+    public boolean isDelivery() {
+        return this == DELIVERY;
+    }
+
+    public boolean isCompany() {
+        return this == COMPANY;
+    }
 }

--- a/src/main/java/com/fhsh/daitda/common/exception/ForbiddenException.java
+++ b/src/main/java/com/fhsh/daitda/common/exception/ForbiddenException.java
@@ -1,0 +1,12 @@
+package com.fhsh.daitda.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/fhsh/daitda/common/util/AuthorizationUtils.java
+++ b/src/main/java/com/fhsh/daitda/common/util/AuthorizationUtils.java
@@ -14,7 +14,7 @@ public final class AuthorizationUtils {
             throw new ForbiddenException("권한 정보가 존재하지 않습니다.");
         }
 
-        if (!(authenticatedUser.isAdmin() || authenticatedUser.isHubAdmin())) {
+        if (!authenticatedUser.isAdmin()) {
             throw new ForbiddenException("해당 요청에 대한 권한이 없습니다.");
         }
     }

--- a/src/main/java/com/fhsh/daitda/common/util/AuthorizationUtils.java
+++ b/src/main/java/com/fhsh/daitda/common/util/AuthorizationUtils.java
@@ -1,5 +1,6 @@
 package com.fhsh.daitda.common.util;
 
+import com.fhsh.daitda.common.enums.UserRole;
 import com.fhsh.daitda.common.exception.ForbiddenException;
 import com.fhsh.daitda.common.model.AuthenticatedUser;
 
@@ -9,12 +10,27 @@ public final class AuthorizationUtils {
         throw new IllegalStateException("Utility class");
     }
 
-    public static void validateAdminOrHubAdmin(AuthenticatedUser authenticatedUser) {
+    public static void validateMasterAccess(AuthenticatedUser authenticatedUser) {
         if (authenticatedUser == null) {
             throw new ForbiddenException("권한 정보가 존재하지 않습니다.");
         }
 
         if (!authenticatedUser.isAdmin()) {
+            throw new ForbiddenException("해당 요청에 대한 권한이 없습니다.");
+        }
+    }
+
+    public static void validateAllAccess(AuthenticatedUser authenticatedUser) {
+        if (authenticatedUser == null) {
+            throw new ForbiddenException("권한 정보가 존재하지 않습니다.");
+        }
+
+        UserRole role = authenticatedUser.role();
+
+        if (!(role.isAdmin()
+                || role.isHubAdmin()
+                || role.isDelivery()
+                || role.isCompany())) {
             throw new ForbiddenException("해당 요청에 대한 권한이 없습니다.");
         }
     }

--- a/src/main/java/com/fhsh/daitda/common/util/AuthorizationUtils.java
+++ b/src/main/java/com/fhsh/daitda/common/util/AuthorizationUtils.java
@@ -1,0 +1,21 @@
+package com.fhsh.daitda.common.util;
+
+import com.fhsh.daitda.common.exception.ForbiddenException;
+import com.fhsh.daitda.common.model.AuthenticatedUser;
+
+public final class AuthorizationUtils {
+
+    private AuthorizationUtils() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static void validateAdminOrHubAdmin(AuthenticatedUser authenticatedUser) {
+        if (authenticatedUser == null) {
+            throw new ForbiddenException("권한 정보가 존재하지 않습니다.");
+        }
+
+        if (!(authenticatedUser.isAdmin() || authenticatedUser.isHubAdmin())) {
+            throw new ForbiddenException("해당 요청에 대한 권한이 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/external/HubController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/external/HubController.java
@@ -2,9 +2,11 @@ package com.fhsh.daitda.hubservice.hub.presentation.controller.external;
 
 import com.fhsh.daitda.common.config.security.SecurityHeaderConstants;
 import com.fhsh.daitda.common.model.AuthenticatedUser;
+import com.fhsh.daitda.common.util.AuthorizationUtils;
 import com.fhsh.daitda.hubservice.hub.application.command.CreateHubCommand;
 import com.fhsh.daitda.hubservice.hub.application.command.UpdateHubCommand;
 import com.fhsh.daitda.hubservice.hub.application.result.FindHubResult;
+import com.fhsh.daitda.hubservice.hub.application.result.ListHubResult;
 import com.fhsh.daitda.hubservice.hub.presentation.dto.request.HubCreateRequest;
 import com.fhsh.daitda.hubservice.hub.presentation.dto.request.HubUpdateRequest;
 import com.fhsh.daitda.hubservice.hub.presentation.dto.response.HubResponse;
@@ -31,6 +33,7 @@ public class HubController {
     /**
      * 허브를 생성
      * 외부 요청은 Gateway를 통해 진입하므로 사용자 헤더를 받아 createdBy에 반영
+     * 명세상 MASTER 권한이 필요한 API이므로 ADMIN 권한으로 매핑하여 검증
      */
     @PostMapping
     public ResponseEntity<HubResponse> createHub(
@@ -40,7 +43,7 @@ public class HubController {
             @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role
     ) {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
-
+        AuthorizationUtils.validateMasterAccess(authenticatedUser);
 
         CreateHubCommand command = CreateHubCommand.builder()
                 .hubName(request.getHubName())
@@ -56,9 +59,21 @@ public class HubController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    /**
+     * 전체 허브 목록을 조회
+     * 명세상 ALL 권한 API이므로 인증된 사용자 역할이면 모두 허용
+     */
     @GetMapping
-    public ResponseEntity<List<ListHubResponse>> getHubs() {
-        List<ListHubResponse> responses = hubService.getHubs()
+    public ResponseEntity<List<ListHubResponse>> getHubs(@RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                                         @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                         @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateAllAccess(authenticatedUser);
+
+        List<ListHubResult> results = hubService.getHubs();
+
+        List<ListHubResponse> responses = results
                 .stream()
                 .map(hub -> ListHubResponse.from(hub))
                 .toList();
@@ -66,14 +81,29 @@ public class HubController {
         return ResponseEntity.ok(responses);
     }
 
+    /**
+     * 허브 ID 기준으로 단건 허브를 조회
+     * 명세상 ALL 권한 API이므로 인증된 사용자 역할이면 모두 허용
+     */
     @GetMapping("/{hubId}")
-    public ResponseEntity<HubResponse> getHub(@PathVariable UUID hubId) {
+    public ResponseEntity<HubResponse> getHub(@PathVariable UUID hubId,
+                                              @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                              @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                              @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateAllAccess(authenticatedUser);
+
         FindHubResult result = hubService.getHub(hubId);
         HubResponse response = HubResponse.from(result);
 
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 허브 정보를 수정
+     * 명세상 MASTER 권한이 필요한 API이므로 ADMIN 권한으로 매핑하여 검증
+     */
     @PatchMapping("/{hubId}")
     public ResponseEntity<HubResponse> updateHub(@PathVariable UUID hubId,
                                                  @Valid @RequestBody HubUpdateRequest request,
@@ -82,6 +112,7 @@ public class HubController {
                                                  @RequestHeader(SecurityHeaderConstants.USER_ROLE)String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateMasterAccess(authenticatedUser);
 
         UpdateHubCommand command = UpdateHubCommand.builder()
                 .hubName(request.getHubName())
@@ -97,6 +128,10 @@ public class HubController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 허브를 논리 삭제
+     * 명세상 MASTER 권한이 필요한 API이므로 ADMIN 권한으로 매핑하여 검증
+     */
     @DeleteMapping("/{hubId}")
     public ResponseEntity<Void> deleteHub(@PathVariable UUID hubId,
                                           @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
@@ -104,6 +139,7 @@ public class HubController {
                                           @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateMasterAccess(authenticatedUser);
 
         hubService.deleteHub(hubId, authenticatedUser.userId());
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/external/HubInventoryController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/external/HubInventoryController.java
@@ -2,9 +2,11 @@ package com.fhsh.daitda.hubservice.hubinventory.presentation.controller.external
 
 import com.fhsh.daitda.common.config.security.SecurityHeaderConstants;
 import com.fhsh.daitda.common.model.AuthenticatedUser;
+import com.fhsh.daitda.common.util.AuthorizationUtils;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.CreateHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.UpdateHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
+import com.fhsh.daitda.hubservice.hubinventory.application.result.ListHubInventoryResult;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request.CreateHubInventoryRequest;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request.UpdateHubInventoryRequest;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response.FindHubInventoryResponse;
@@ -28,7 +30,10 @@ public class HubInventoryController {
         this.hubInventoryService = hubInventoryService;
     }
 
-    // 재고 생성
+    /**
+     * 허브 재고를 등록
+     * 명세상 MASTER 권한이 필요한 API이므로 현재 인증 시스템에서는 ADMIN 권한으로 매핑하여 검증
+     */
     @PostMapping
     public ResponseEntity<FindHubInventoryResponse> createHubInventory(@Valid @RequestBody CreateHubInventoryRequest request,
                                                                        @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
@@ -36,6 +41,7 @@ public class HubInventoryController {
                                                                        @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateMasterAccess(authenticatedUser);
 
         CreateHubInventoryCommand command = CreateHubInventoryCommand.builder()
                 .hubId(request.getHubId())
@@ -50,38 +56,71 @@ public class HubInventoryController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    // 전체 재고 목록 조회
+    /**
+     * 전체 허브 재고 목록을 조회
+     * 명세상 ALL 권한 API이므로 인증된 사용자 역할이면 모두 허용
+     */
     @GetMapping
-    public ResponseEntity<List<ListHubInventoryResponse>> getHubInventories() {
-        List<ListHubInventoryResponse> responses = hubInventoryService.getHubInventories()
-                .stream()
+    public ResponseEntity<List<ListHubInventoryResponse>> getHubInventories(@RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                                                            @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL,required = false) String email,
+                                                                            @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateAllAccess(authenticatedUser);
+
+        List<ListHubInventoryResult> results = hubInventoryService.getHubInventories();
+
+        List<ListHubInventoryResponse> responses = results.stream()
                 .map(response -> ListHubInventoryResponse.from(response))
                 .toList();
 
         return ResponseEntity.ok(responses);
     }
 
-    // hubId + companyId + productId 조합으로 특정 허브 재고 조회
+    /**
+     * hubId + companyId + productId 조합으로 특정 허브 재고를 조회
+     * 명세상 ALL 권한 API이므로 인증된 사용자 역할이면 모두 허용
+     */
     @GetMapping("/search")
     public ResponseEntity<FindHubInventoryResponse> searchHubInventory(@RequestParam UUID hubId,
-                                                                         @RequestParam UUID companyId,
-                                                                         @RequestParam UUID productId) {
+                                                                       @RequestParam UUID companyId,
+                                                                       @RequestParam UUID productId,
+                                                                       @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                                                       @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                                       @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateAllAccess(authenticatedUser);
+
         FindHubInventoryResult result = hubInventoryService.searchHubInventory(hubId, companyId, productId);
         FindHubInventoryResponse response = FindHubInventoryResponse.from(result);
 
         return ResponseEntity.ok(response);
     }
 
-    // 특정 허브 재고 상세 조회
+    /**
+     * 허브 재고 ID 기준으로 단건 재고를 조회
+     * 명세상 ALL 권한 API이므로 인증된 사용자 역할이면 모두 허용
+     */
     @GetMapping("/{hubInventoryId}")
-    public ResponseEntity<FindHubInventoryResponse> getHubInventory(@PathVariable UUID hubInventoryId) {
+    public ResponseEntity<FindHubInventoryResponse> getHubInventory(@PathVariable UUID hubInventoryId,
+                                                                    @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                                                    @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                                    @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateAllAccess(authenticatedUser);
+
         FindHubInventoryResult result = hubInventoryService.getHubInventory(hubInventoryId);
         FindHubInventoryResponse response = FindHubInventoryResponse.from(result);
 
         return ResponseEntity.ok(response);
     }
 
-    // 재고 수량 직접 수정
+    /**
+     * 허브 재고 수량을 수정
+     * 명세상 MASTER 권한이 필요한 API이므로 현재 인증 시스템에서는 ADMIN 권한으로 매핑하여 검증
+     */
     @PatchMapping("/{hubInventoryId}")
     public ResponseEntity<FindHubInventoryResponse> updateHubInventory(@PathVariable UUID hubInventoryId,
                                                                        @Valid @RequestBody UpdateHubInventoryRequest request,
@@ -90,6 +129,7 @@ public class HubInventoryController {
                                                                        @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateMasterAccess(authenticatedUser);
 
         UpdateHubInventoryCommand command = UpdateHubInventoryCommand.builder()
                 .quantity(request.getQuantity())
@@ -101,7 +141,10 @@ public class HubInventoryController {
         return ResponseEntity.ok(response);
     }
 
-    // 재고 논리 삭제
+    /**
+     * 허브 재고를 논리 삭제
+     * 명세상 MASTER 권한이 필요한 API이므로 현재 인증 시스템에서는 ADMIN 권한으로 매핑하여 검증
+     */
     @DeleteMapping("/{hubInventoryId}")
     public ResponseEntity<Void> deleteHubInventory(@PathVariable UUID hubInventoryId,
                                                    @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
@@ -109,6 +152,8 @@ public class HubInventoryController {
                                                    @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateMasterAccess(authenticatedUser);
+
         hubInventoryService.deleteHubInventory(hubInventoryId, authenticatedUser.userId());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/external/HubRouteController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/external/HubRouteController.java
@@ -2,6 +2,7 @@ package com.fhsh.daitda.hubservice.hubroute.presentation.controller.external;
 
 import com.fhsh.daitda.common.config.security.SecurityHeaderConstants;
 import com.fhsh.daitda.common.model.AuthenticatedUser;
+import com.fhsh.daitda.common.util.AuthorizationUtils;
 import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.application.result.ListHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.application.service.HubRouteService;
@@ -26,7 +27,8 @@ public class HubRouteController {
     }
 
     /**
-     * 출발 허브와 도착 허브 기준의 허브 경로 생성
+     * 출발 허브와 도착 허브 기준의 허브 경로를 생성
+     * 명세상 MASTER 권한이 필요한 API이므로 현재 인증 시스템에서는 ADMIN 권한으로 매핑하여 검증
      */
     @PostMapping
     public FindHubRouteResponse createHubRoute(@Valid @RequestBody CreateHubRouteRequest request,
@@ -35,16 +37,24 @@ public class HubRouteController {
                                                @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateMasterAccess(authenticatedUser);
 
         FindHubRouteResult result = hubRouteService.createHubRoute(request.toCommand(), authenticatedUser.userId());
         return FindHubRouteResponse.from(result);
     }
 
     /**
-     * 삭제되지 않은 전체 허브 경로 목록 조회
+     * 삭제되지 않은 전체 허브 경로 목록을 조회
+     * 명세상 ALL 권한 API이므로 인증된 사용자 역할이면 모두 허용
      */
     @GetMapping
-    public List<ListHubRouteResponse> getHubRoutes() {
+    public List<ListHubRouteResponse> getHubRoutes(@RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                                   @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                                   @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateAllAccess(authenticatedUser);
+
         List<ListHubRouteResult> results = hubRouteService.getHubRoutes();
 
         return results.stream()
@@ -53,28 +63,43 @@ public class HubRouteController {
     }
 
     /**
-     * 허브 경로 ID 기준으로 단건 상세 정보 조회
+     * 허브 경로 ID 기준으로 단건 상세 정보를 조회
+     * 명세상 ALL 권한 API이므로 인증된 사용자 역할이면 모두 허용
      */
     @GetMapping("/{hubRouteId}")
-    public FindHubRouteResponse getHubRoute(@PathVariable UUID hubRouteId) {
+    public FindHubRouteResponse getHubRoute(@PathVariable UUID hubRouteId,
+                                            @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                            @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                            @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateAllAccess(authenticatedUser);
+
         FindHubRouteResult result = hubRouteService.getHubRoute(hubRouteId);
         return FindHubRouteResponse.from(result);
     }
 
     /**
-     * 출발 허브와 도착 허브 조합으로 허브 경로 조회
+     * 출발 허브와 도착 허브 조합으로 허브 경로를 조회
+     * 명세상 ALL 권한 API이므로 인증된 사용자 역할이면 모두 허용
      */
     @GetMapping("/search")
-    public FindHubRouteResponse searchHubRoute(
-            @RequestParam UUID srcHubId,
-            @RequestParam UUID destHubId
-    ) {
+    public FindHubRouteResponse searchHubRoute(@RequestParam UUID srcHubId,
+                                               @RequestParam UUID destHubId,
+                                               @RequestHeader(SecurityHeaderConstants.USER_ID) String userId,
+                                               @RequestHeader(value = SecurityHeaderConstants.USER_EMAIL, required = false) String email,
+                                               @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
+    {
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateAllAccess(authenticatedUser);
+
         FindHubRouteResult result = hubRouteService.searchHubRoute(srcHubId, destHubId);
         return FindHubRouteResponse.from(result);
     }
 
     /**
-     * 허브 경로의 소요 시간과 이동 거리 수정
+     * 허브 경로의 소요 시간과 이동 거리를 수정
+     * 명세상 MASTER 권한이 필요한 API이므로 현재 인증 시스템에서는 ADMIN 권한으로 매핑하여 검증
      */
     @PatchMapping("/{hubRouteId}")
     public FindHubRouteResponse updateHubRoute(@PathVariable UUID hubRouteId,
@@ -84,6 +109,7 @@ public class HubRouteController {
                                                @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateMasterAccess(authenticatedUser);
 
         FindHubRouteResult result = hubRouteService.updateHubRoute(hubRouteId, request.toCommand(), authenticatedUser.userId());
         return FindHubRouteResponse.from(result);
@@ -91,7 +117,8 @@ public class HubRouteController {
 
     /**
      * 허브 경로를 논리 삭제
-     * 지금은 삭제 성공 여부만 의미가 있어 별도 응답 본문 없이 void로 처리
+     * 지금은 삭제 성공 여부만 의미가 있어 별도 응답 본문 없이 void처리
+     * 명세상 MASTER 권한이 필요한 API이므로 현재 인증 시스템에서는 ADMIN 권한으로 매핑하여 검증
      */
     @DeleteMapping("/{hubRouteId}")
     public void deleteHubRoute(@PathVariable UUID hubRouteId,
@@ -100,6 +127,7 @@ public class HubRouteController {
                                @RequestHeader(SecurityHeaderConstants.USER_ROLE) String role)
     {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.fromHeaders(userId, email, role);
+        AuthorizationUtils.validateMasterAccess(authenticatedUser);
 
         hubRouteService.deleteHubRoute(hubRouteId, authenticatedUser.userId());
     }


### PR DESCRIPTION
## 🌱 설명

hub-service의 external API에 권한 기반 인가 정책을 추가

이전 작업에서 Gateway가 전달하는 사용자 헤더를 수신하고 audit 값에 반영하는 구조를 적용한 상태
이번 PR에서는 `X-User-Role` 값을 기반으로 external API 접근 권한을 검증하도록 인가 로직을 반영

명세서 기준 `MASTER` 권한이 필요한 API와 `ALL` 권한이 필요한 API를 분리해서 적용


## 📌 관련 이슈

- close #23 

## ✅ 주요 변경 사항

- `ForbiddenException` 추가
- `AuthorizationUtils` 추가
- `MASTER` 권한 검증 로직 추가
- `ALL` 권한 검증 로직 추가
- `HubController` external API 인가 적용
- `HubInventoryController` external API 인가 적용
- `HubRouteController` external API 인가 적용
- `create / update / delete` API에 `MASTER` 권한 적용
- `list / get / search` API에 `ALL` 권한 적용
- external API에서 사용자 헤더 기반 인가 처리 반영
- internal API는 기존 내부 호출 정책 유지

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- external API는 Gateway를 통해 진입하므로 `X-User-Id`, `X-User-Email`, `X-User-Role` 헤더 기반으로 인가를 처리
- `/internal/**` 경로는 내부 서비스 간 통신 전용이므로 이번 PR 인가 적용 대상에서 제외
- 테스트 계획 중 자동화 테스트는 별도 보강이 필요하면 후속 작업으로 진행할 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 보안 헤더 검증 로직 개선으로 클래스 구조 강화
  * 사용자 역할별 접근 제어 메커니즘 추가
  * 허브, 허브 인벤토리 및 허브 경로 관련 API 엔드포인트에 인증 및 권한 검증 강화
  * 관리자 및 일반 사용자 역할에 따른 차등화된 접근 권한 체계 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->