### PR TITLE
[feature] implement remaining core features in hub service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'com.fhsh.daitda:common:0.1.1-SNAPSHOT'
+    implementation 'com.fhsh.daitda:common:0.1.4-SNAPSHOT'
 }
 
 dependencyManagement {

--- a/src/main/java/com/fhsh/daitda/common/model/AuthenticatedUser.java
+++ b/src/main/java/com/fhsh/daitda/common/model/AuthenticatedUser.java
@@ -3,8 +3,10 @@ package com.fhsh.daitda.common.model;
 import com.fhsh.daitda.common.enums.UserRole;
 import com.fhsh.daitda.common.exception.InvalidAuthenticationHeaderException;
 
+import java.util.UUID;
+
 public record AuthenticatedUser(
-        String userId,
+        UUID userId,
         String email,
         UserRole role
 ) {
@@ -13,8 +15,15 @@ public record AuthenticatedUser(
             throw new InvalidAuthenticationHeaderException("사용자 식별 헤더가 존재하지 않습니다.");
         }
 
+        UUID parsedUserId;
+        try {
+            parsedUserId = UUID.fromString(userId);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidAuthenticationHeaderException("사용자 식별 헤더 형식이 올바르지 않습니다.");
+        }
+
         return new AuthenticatedUser(
-                userId,
+                parsedUserId,
                 email != null ? email : "",
                 UserRole.from(role)
         );

--- a/src/main/java/com/fhsh/daitda/hubservice/hub/application/service/command/HubCommandService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hub/application/service/command/HubCommandService.java
@@ -36,7 +36,7 @@ public class HubCommandService {
      * - createdBy를 받아 audit 값을 남기므로 쓰기 성격이 명확하기 때문
      */
     @Transactional
-    public FindHubResult createHub(CreateHubCommand command, String createdBy) {
+    public FindHubResult createHub(CreateHubCommand command, UUID createdBy) {
         Hub hub = Hub.create(
                 command.getHubName(),
                 command.getHubAddress(),
@@ -54,7 +54,7 @@ public class HubCommandService {
      * 허브 정보 수정
      */
     @Transactional
-    public FindHubResult updateHub(UUID hubId, UpdateHubCommand command, String updatedBy) {
+    public FindHubResult updateHub(UUID hubId, UpdateHubCommand command, UUID updatedBy) {
         Hub hub = findActiveHub(hubId);
 
         hub.update(
@@ -72,7 +72,7 @@ public class HubCommandService {
      * 허브 논리 삭제
      */
     @Transactional
-    public void deleteHub(UUID hubId, String deletedBy) {
+    public void deleteHub(UUID hubId, UUID deletedBy) {
         Hub hub = findActiveHub(hubId);
         hub.softDelete(deletedBy);
     }

--- a/src/main/java/com/fhsh/daitda/hubservice/hub/domain/entity/Hub.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hub/domain/entity/Hub.java
@@ -50,7 +50,7 @@ public class Hub extends BaseUserEntity {
     }
 
     public static Hub create(String hubName, String hubAddress, BigDecimal latitude,
-                             BigDecimal longitude, boolean isCentral, String createdBy) {
+                             BigDecimal longitude, boolean isCentral, UUID createdBy) {
 
         Hub hub =  Hub.builder()
                 .hubName(hubName)
@@ -72,7 +72,7 @@ public class Hub extends BaseUserEntity {
     }
 
     public void update(String hubName, String hubAddress, BigDecimal latitude,
-                       BigDecimal longitude, Boolean isCentral, String updatedBy) {
+                       BigDecimal longitude, Boolean isCentral, UUID updatedBy) {
 
         this.hubName = hubName;
         this.hubAddress = hubAddress;
@@ -82,7 +82,7 @@ public class Hub extends BaseUserEntity {
         this.updatedBy = updatedBy;
     }
 
-    public void softDelete(String deletedBy) {
+    public void softDelete(UUID deletedBy) {
         delete(deletedBy);
     }
 

--- a/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/internal/HubInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/internal/HubInternalController.java
@@ -3,6 +3,7 @@ package com.fhsh.daitda.hubservice.hub.presentation.controller.internal;
 import com.fhsh.daitda.hubservice.hub.application.result.FindHubResult;
 import com.fhsh.daitda.hubservice.hub.application.service.query.HubQueryService;
 import com.fhsh.daitda.hubservice.hub.presentation.dto.response.HubResponse;
+import com.fhsh.daitda.response.CommonResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,8 +22,8 @@ public class HubInternalController {
     }
 
     @GetMapping("/{hubId}")
-    public HubResponse getHub(@PathVariable UUID hubId) {
+    public CommonResponse<HubResponse> getHub(@PathVariable UUID hubId) {
         FindHubResult result = hubQueryService.getHub(hubId);
-        return HubResponse.from(result);
+        return CommonResponse.success(HubResponse.from(result));
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/internal/HubInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hub/presentation/controller/internal/HubInternalController.java
@@ -1,0 +1,28 @@
+package com.fhsh.daitda.hubservice.hub.presentation.controller.internal;
+
+import com.fhsh.daitda.hubservice.hub.application.result.FindHubResult;
+import com.fhsh.daitda.hubservice.hub.application.service.query.HubQueryService;
+import com.fhsh.daitda.hubservice.hub.presentation.dto.response.HubResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/internal/v1/hubs")
+public class HubInternalController {
+
+    private final HubQueryService hubQueryService;
+
+    public HubInternalController(HubQueryService hubQueryService) {
+        this.hubQueryService = hubQueryService;
+    }
+
+    @GetMapping("/{hubId}")
+    public HubResponse getHub(@PathVariable UUID hubId) {
+        FindHubResult result = hubQueryService.getHub(hubId);
+        return HubResponse.from(result);
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/command/DecreaseHubInventoriesByProductCommand.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/command/DecreaseHubInventoriesByProductCommand.java
@@ -1,0 +1,34 @@
+package com.fhsh.daitda.hubservice.hubinventory.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+// 주문 생성용 재고 차감 command
+@Getter
+@Builder
+public class DecreaseHubInventoriesByProductCommand {
+
+    /**
+     * 공급 업체 회사 ID
+     * 한 회사는 한 허브에만 물건을 둠
+     * supplierCompanyId + productId 로
+     * 실제 재고 row를 찾는 데 사용
+     */
+    private UUID supplierCompanyId;
+
+    /**
+     * 주문 항목 목록
+     */
+    private List<Item> orderItems;
+
+    // 개별 주문 항목 command
+    @Getter
+    @Builder
+    public static class Item{
+        private UUID productId;
+        private Integer quantity;
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/command/DecreaseHubInventoriesCommand.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/command/DecreaseHubInventoriesCommand.java
@@ -14,7 +14,7 @@ public class DecreaseHubInventoriesCommand {
 
     @Getter
     @Builder
-    private static class Item{
+    public static class Item{
         private UUID hubInventoryId;
         private Integer quantity;
     }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/command/DecreaseHubInventoriesCommand.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/command/DecreaseHubInventoriesCommand.java
@@ -1,0 +1,21 @@
+package com.fhsh.daitda.hubservice.hubinventory.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class DecreaseHubInventoriesCommand {
+
+    private List<Item> items;
+
+    @Getter
+    @Builder
+    private static class Item{
+        private UUID hubInventoryId;
+        private Integer quantity;
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/command/RestoreHubInventoriesCommand.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/command/RestoreHubInventoriesCommand.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 @Getter
 @Builder
-public class RestoreHubInventoryCommand {
+public class RestoreHubInventoriesCommand {
 
     // 복원 대상 목록
     private List<Item> orderItems;

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/command/RestoreHubInventoryCommand.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/command/RestoreHubInventoryCommand.java
@@ -3,12 +3,21 @@ package com.fhsh.daitda.hubservice.hubinventory.application.command;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.UUID;
 
 @Getter
 @Builder
 public class RestoreHubInventoryCommand {
 
-    private UUID hubInventoryId;
-    private Integer quantity;
+    // 복원 대상 목록
+    private List<Item> orderItems;
+
+    // 개별 복원 항목
+    @Getter
+    @Builder
+    public static class Item {
+        private UUID hubInventoryId;
+        private Integer quantity;
+    }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/result/DecreaseHubInventoriesByProductResult.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/result/DecreaseHubInventoriesByProductResult.java
@@ -1,0 +1,24 @@
+package com.fhsh.daitda.hubservice.hubinventory.application.result;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class DecreaseHubInventoriesByProductResult {
+
+    // 상품별 실제 차감에 사용된 재고 row 정보
+    private List<Item> items;
+
+    @Getter
+    @Builder
+    private static class Item{
+        // 실제 차감에 사용한 재고 row PK
+        private UUID hubInventoryId;
+        // 어떤 상품에 대한 결과인지 식별하기 위해 포함
+        private UUID productId;
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/result/DecreaseHubInventoriesByProductResult.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/result/DecreaseHubInventoriesByProductResult.java
@@ -15,7 +15,7 @@ public class DecreaseHubInventoriesByProductResult {
 
     @Getter
     @Builder
-    private static class Item{
+    public static class Item{
         // 실제 차감에 사용한 재고 row PK
         private UUID hubInventoryId;
         // 어떤 상품에 대한 결과인지 식별하기 위해 포함

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
@@ -76,22 +76,36 @@ public class HubInventoryCommandService {
                 .toList();
     }
 
-    public DecreaseHubInventoriesByProductResult decreaseHubInventoriesByProduct(DecreaseHubInventoriesByProductCommand command, UUID updatedBy) {
-
+    public DecreaseHubInventoriesByProductResult decreaseHubInventoriesByProduct(
+            DecreaseHubInventoriesByProductCommand command,
+            UUID updatedBy
+    ) {
         List<DecreaseHubInventoriesByProductResult.Item> items = command.getOrderItems().stream()
                 .map(orderItem -> {
-                    // 회사 + 상품 기준으로 실제 재고 조회
-                    HubInventory hubInventory = hubInventoryRepository
-                            .findByCompanyIdAndProductIdAndDeletedAtIsNull(
+                    // 회사 + 상품 기준으로 조회
+                    List<HubInventory> hubInventories = hubInventoryRepository
+                            .findAllByCompanyIdAndProductIdAndDeletedAtIsNull(
                                     command.getSupplierCompanyId(),
                                     orderItem.getProductId()
-                            )
-                            .orElseThrow(() -> new BusinessException(HubInventoryErrorCode.HUB_INVENTORY_NOT_FOUND));
+                            );
+
+                    // 조회 결과가 없으면 재고가 없는 것이므로 비즈니스 예외 처리
+                    if (hubInventories.isEmpty()) {
+                        throw new BusinessException(HubInventoryErrorCode.HUB_INVENTORY_NOT_FOUND);
+                    }
+
+                    // 현재 전제상 단건이어야 하므로, 복수 조회는 데이터 이상 상태로 간주
+                    if (hubInventories.size() > 1) {
+                        throw new IllegalStateException("companyId와 productId 기준 재고가 복수로 조회되었습니다.");
+                    }
+
+                    // 정상 케이스: 정확히 1건 조회
+                    HubInventory hubInventory = hubInventories.get(0);
 
                     // 실제 재고 수량 차감
                     hubInventory.decrease(orderItem.getQuantity(), updatedBy);
 
-                    // 어떤 row 사용했는지 결과 반환
+                    // 어떤 row를 사용했는지 결과 반환
                     return DecreaseHubInventoriesByProductResult.Item.builder()
                             .hubInventoryId(hubInventory.getHubInventoryId())
                             .productId(hubInventory.getProductId())

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
@@ -27,7 +27,7 @@ public class HubInventoryCommandService {
 
     // 재고생성
     @Transactional
-    public FindHubInventoryResult createHubInventory(CreateHubInventoryCommand command, String createdBy) {
+    public FindHubInventoryResult createHubInventory(CreateHubInventoryCommand command, UUID createdBy) {
         validateDuplicateHubInventory(command.getHubId(), command.getCompanyId(), command.getProductId());
 
         HubInventory hubInventory = HubInventory.create(
@@ -48,7 +48,7 @@ public class HubInventoryCommandService {
 
     // 재고 수량 수정
     @Transactional
-    public FindHubInventoryResult updateHubInventory(UUID hubInventoryId, UpdateHubInventoryCommand command, String updatedBy) {
+    public FindHubInventoryResult updateHubInventory(UUID hubInventoryId, UpdateHubInventoryCommand command, UUID updatedBy) {
         HubInventory hubInventory = findActiveHubInventory(hubInventoryId);
 
         hubInventory.updateQuantity(command.getQuantity(), updatedBy);
@@ -58,7 +58,7 @@ public class HubInventoryCommandService {
 
     // 재고 차감
     @Transactional
-    public FindHubInventoryResult decreaseHubInventory(DecreaseHubInventoryCommand command, String updatedBy) {
+    public FindHubInventoryResult decreaseHubInventory(DecreaseHubInventoryCommand command, UUID updatedBy) {
         HubInventory hubInventory = findActiveHubInventory(command.getHubInventoryId());
 
         hubInventory.decrease(command.getQuantity(), updatedBy);
@@ -66,7 +66,7 @@ public class HubInventoryCommandService {
         return FindHubInventoryResult.from(hubInventory);
     }
 
-    public List<FindHubInventoryResult> decreaseHubInventories(DecreaseHubInventoriesCommand command, String updatedBy) {
+    public List<FindHubInventoryResult> decreaseHubInventories(DecreaseHubInventoriesCommand command, UUID updatedBy) {
         return command.getItems().stream()
                 .map(item -> {
                     HubInventory hubInventory = findActiveHubInventory(item.getHubInventoryId());
@@ -76,7 +76,7 @@ public class HubInventoryCommandService {
                 .toList();
     }
 
-    public DecreaseHubInventoriesByProductResult decreaseHubInventoriesByProduct(DecreaseHubInventoriesByProductCommand command, String updatedBy) {
+    public DecreaseHubInventoriesByProductResult decreaseHubInventoriesByProduct(DecreaseHubInventoriesByProductCommand command, UUID updatedBy) {
 
         List<DecreaseHubInventoriesByProductResult.Item> items = command.getOrderItems().stream()
                 .map(orderItem -> {
@@ -106,7 +106,7 @@ public class HubInventoryCommandService {
 
     // 재고 복원
     @Transactional
-    public void restoreHubInventories(RestoreHubInventoriesCommand command, String updatedBy) {
+    public void restoreHubInventories(RestoreHubInventoriesCommand command, UUID updatedBy) {
         command.getOrderItems().forEach(orderItem -> {
             // 실제 복원 대상 재고 조회
             HubInventory hubInventory = findActiveHubInventory(orderItem.getHubInventoryId());
@@ -117,7 +117,7 @@ public class HubInventoryCommandService {
 
     // 논리 삭제
     @Transactional
-    public void deleteHubInventory(UUID hubInventoryId, String deletedBy) {
+    public void deleteHubInventory(UUID hubInventoryId, UUID deletedBy) {
         HubInventory hubInventory = findActiveHubInventory(hubInventoryId);
         hubInventory.softDelete(deletedBy);
     }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
@@ -2,6 +2,7 @@ package com.fhsh.daitda.hubservice.hubinventory.application.service.command;
 
 import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.*;
+import com.fhsh.daitda.hubservice.hubinventory.application.result.DecreaseHubInventoriesByProductResult;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
 import com.fhsh.daitda.hubservice.hubinventory.domain.entity.HubInventory;
 import com.fhsh.daitda.hubservice.hubinventory.domain.exception.HubInventoryErrorCode;
@@ -73,6 +74,34 @@ public class HubInventoryCommandService {
                     return FindHubInventoryResult.from(hubInventory);
                 })
                 .toList();
+    }
+
+    public DecreaseHubInventoriesByProductResult decreaseHubInventoriesByProductResult(DecreaseHubInventoriesByProductCommand command, String updatedBy) {
+
+        List<DecreaseHubInventoriesByProductResult.Item> items = command.getOrderItems().stream()
+                .map(orderItem -> {
+                    // 회사 + 상품 기준으로 실제 재고 조회
+                    HubInventory hubInventory = hubInventoryRepository
+                            .findByCompanyIdAndProductIdAndDeletedAtIsNull(
+                                    command.getSupplierCompanyId(),
+                                    orderItem.getProductId()
+                            )
+                            .orElseThrow(() -> new BusinessException(HubInventoryErrorCode.HUB_INVENTORY_NOT_FOUND));
+
+                    // 실제 재고 수량 차감
+                    hubInventory.decrease(orderItem.getQuantity(), updatedBy);
+
+                    // 어떤 row 사용했는지 결과 반환
+                    return DecreaseHubInventoriesByProductResult.Item.builder()
+                            .hubInventoryId(hubInventory.getHubInventoryId())
+                            .productId(hubInventory.getProductId())
+                            .build();
+                })
+                .toList();
+
+        return DecreaseHubInventoriesByProductResult.builder()
+                .items(items)
+                .build();
     }
 
     // 재고 복원

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
@@ -106,12 +106,13 @@ public class HubInventoryCommandService {
 
     // 재고 복원
     @Transactional
-    public FindHubInventoryResult restoreHubInventory(RestoreHubInventoryCommand command, String updatedBy) {
-        HubInventory hubInventory = findActiveHubInventory(command.getHubInventoryId());
-
-        hubInventory.restoreQuantity(command.getQuantity(), updatedBy);
-
-        return FindHubInventoryResult.from(hubInventory);
+    public void restoreHubInventories(RestoreHubInventoryCommand command, String updatedBy) {
+        command.getOrderItems().forEach(orderItem -> {
+            // 실제 복원 대상 재고 조회
+            HubInventory hubInventory = findActiveHubInventory(orderItem.getHubInventoryId());
+            // 조회한 재고 수량 복원
+            hubInventory.restoreQuantity(orderItem.getQuantity(), updatedBy);
+        });
     }
 
     // 논리 삭제

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
@@ -1,10 +1,7 @@
 package com.fhsh.daitda.hubservice.hubinventory.application.service.command;
 
 import com.fhsh.daitda.exception.BusinessException;
-import com.fhsh.daitda.hubservice.hubinventory.application.command.CreateHubInventoryCommand;
-import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoryCommand;
-import com.fhsh.daitda.hubservice.hubinventory.application.command.RestoreHubInventoryCommand;
-import com.fhsh.daitda.hubservice.hubinventory.application.command.UpdateHubInventoryCommand;
+import com.fhsh.daitda.hubservice.hubinventory.application.command.*;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
 import com.fhsh.daitda.hubservice.hubinventory.domain.entity.HubInventory;
 import com.fhsh.daitda.hubservice.hubinventory.domain.exception.HubInventoryErrorCode;
@@ -13,6 +10,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 // 허브 재고 도메인의 쓰기 작업(Create /Update/Delete)을 담당
@@ -65,6 +63,16 @@ public class HubInventoryCommandService {
         hubInventory.decrease(command.getQuantity(), updatedBy);
 
         return FindHubInventoryResult.from(hubInventory);
+    }
+
+    public List<FindHubInventoryResult> decreaseHubInventories(DecreaseHubInventoriesCommand command, String updatedBy) {
+        return command.getItems().stream()
+                .map(item -> {
+                    HubInventory hubInventory = findActiveHubInventory(item.getHubInventoryId());
+                    hubInventory.decrease(item.getQuantity(), updatedBy);
+                    return FindHubInventoryResult.from(hubInventory);
+                })
+                .toList();
     }
 
     // 재고 복원

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
@@ -106,7 +106,7 @@ public class HubInventoryCommandService {
 
     // 재고 복원
     @Transactional
-    public void restoreHubInventories(RestoreHubInventoryCommand command, String updatedBy) {
+    public void restoreHubInventories(RestoreHubInventoriesCommand command, String updatedBy) {
         command.getOrderItems().forEach(orderItem -> {
             // 실제 복원 대상 재고 조회
             HubInventory hubInventory = findActiveHubInventory(orderItem.getHubInventoryId());

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
@@ -96,7 +96,7 @@ public class HubInventoryCommandService {
 
                     // 현재 전제상 단건이어야 하므로, 복수 조회는 데이터 이상 상태로 간주
                     if (hubInventories.size() > 1) {
-                        throw new IllegalStateException("companyId와 productId 기준 재고가 복수로 조회되었습니다.");
+                        throw new BusinessException(HubInventoryErrorCode.HUB_INVENTORY_DUPLICATED_RESULT);
                     }
 
                     // 정상 케이스: 정확히 1건 조회

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/application/service/command/HubInventoryCommandService.java
@@ -76,7 +76,7 @@ public class HubInventoryCommandService {
                 .toList();
     }
 
-    public DecreaseHubInventoriesByProductResult decreaseHubInventoriesByProductResult(DecreaseHubInventoriesByProductCommand command, String updatedBy) {
+    public DecreaseHubInventoriesByProductResult decreaseHubInventoriesByProduct(DecreaseHubInventoriesByProductCommand command, String updatedBy) {
 
         List<DecreaseHubInventoriesByProductResult.Item> items = command.getOrderItems().stream()
                 .map(orderItem -> {

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/domain/entity/HubInventory.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/domain/entity/HubInventory.java
@@ -53,7 +53,7 @@ public class HubInventory extends BaseUserEntity {
     }
 
     public static HubInventory create(UUID hubId, UUID companyId, UUID productId,
-                                      Integer quantity, String createdBy) {
+                                      Integer quantity, UUID createdBy) {
 
         validateRequiredIds(hubId, companyId, productId);
         validateNonNegativeQuantity(quantity);
@@ -76,14 +76,14 @@ public class HubInventory extends BaseUserEntity {
         }
     }
 
-    public void updateQuantity(Integer quantity, String updatedBy) {
+    public void updateQuantity(Integer quantity, UUID updatedBy) {
         validateNonNegativeQuantity(quantity);
 
         this.quantity = quantity;
         this.updatedBy = updatedBy;
     }
 
-    public void decrease(Integer quantity, String updatedBy) {
+    public void decrease(Integer quantity, UUID updatedBy) {
         validatePositiveQuantity(quantity);
 
         if (this.quantity < quantity) {
@@ -94,14 +94,14 @@ public class HubInventory extends BaseUserEntity {
         this.updatedBy = updatedBy;
     }
 
-    public void restoreQuantity(Integer quantity, String restoredBy) {
+    public void restoreQuantity(Integer quantity, UUID restoredBy) {
         validatePositiveQuantity(quantity);
 
         this.quantity += quantity;
         this.updatedBy = restoredBy;
     }
 
-    public void softDelete(String deletedBy) {
+    public void softDelete(UUID deletedBy) {
         delete(deletedBy);
     }
 

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/domain/exception/HubInventoryErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/domain/exception/HubInventoryErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum HubInventoryErrorCode implements ErrorCode {
 
     HUB_INVENTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "허브 재고를 찾을 수 없습니다."),
-    HUB_INVENTORY_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 허브 재고입니다.");
+    HUB_INVENTORY_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 허브 재고입니다."),
+    HUB_INVENTORY_DUPLICATED_RESULT(HttpStatus.CONFLICT, "허브 재고가 복수로 조회되었습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/domain/repository/HubInventoryRepository.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/domain/repository/HubInventoryRepository.java
@@ -13,7 +13,7 @@ public interface HubInventoryRepository extends JpaRepository<HubInventory, UUID
 
     Optional<HubInventory> findByHubIdAndCompanyIdAndProductIdAndDeletedAtIsNull(UUID hubId, UUID companyId, UUID productId);
 
-    Optional<HubInventory> findByCompanyIdAndProductIdAndDeletedAtIsNull(UUID companyId, UUID productId);
+    List<HubInventory> findAllByCompanyIdAndProductIdAndDeletedAtIsNull(UUID companyId, UUID productId);
 
     List<HubInventory> findAllByHubIdAndDeletedAtIsNull(UUID hubId);
 

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/domain/repository/HubInventoryRepository.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/domain/repository/HubInventoryRepository.java
@@ -13,6 +13,8 @@ public interface HubInventoryRepository extends JpaRepository<HubInventory, UUID
 
     Optional<HubInventory> findByHubIdAndCompanyIdAndProductIdAndDeletedAtIsNull(UUID hubId, UUID companyId, UUID productId);
 
+    Optional<HubInventory> findByCompanyIdAndProductIdAndDeletedAtIsNull(UUID companyId, UUID productId);
+
     List<HubInventory> findAllByHubIdAndDeletedAtIsNull(UUID hubId);
 
     List<HubInventory> findAllByDeletedAtIsNull();

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
@@ -1,7 +1,5 @@
 package com.fhsh.daitda.hubservice.hubinventory.presentation.controller.internal;
 
-import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoryCommand;
-import com.fhsh.daitda.hubservice.hubinventory.application.command.RestoreHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.DecreaseHubInventoriesByProductResult;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
 import com.fhsh.daitda.hubservice.hubinventory.application.service.command.HubInventoryCommandService;
@@ -10,7 +8,6 @@ import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request.Decrease
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request.RestoreHubInventoryRequest;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response.DecreaseHubInventoriesByProductResponse;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response.DecreaseHubInventoriesResponse;
-import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response.FindHubInventoryResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -56,15 +53,9 @@ public class HubInventoryInternalController {
     }
 
     // 재고 복원
-    @PatchMapping("/restore")
-    public ResponseEntity<FindHubInventoryResponse> restoreHubInventory(@Valid @RequestBody RestoreHubInventoryRequest request) {
-        RestoreHubInventoryCommand command = RestoreHubInventoryCommand.builder()
-                .hubInventoryId(request.getHubInventoryId())
-                .quantity(request.getQuantity())
-                .build();
-
-        FindHubInventoryResult result = hubInventoryCommandService.restoreHubInventory(command, null);
-
-        return ResponseEntity.ok(FindHubInventoryResponse.from(result));
+    @PatchMapping("/restoration")
+    public ResponseEntity<Void> restoreHubInventory(@Valid @RequestBody RestoreHubInventoryRequest request) {
+        hubInventoryCommandService.restoreHubInventories(request.toCommand(), null);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
@@ -21,7 +21,6 @@ import java.util.List;
 @RequestMapping("/internal/v1/hub-inventories")
 public class HubInventoryInternalController {
 
-    private static final String INTERNAL_SYSTEM = "SYSTEM";
 
     private final HubInventoryCommandService hubInventoryCommandService;
 
@@ -33,7 +32,7 @@ public class HubInventoryInternalController {
     @PatchMapping("/decrease")
     public CommonResponse<DecreaseHubInventoriesResponse> decreaseHubInventory(@Valid @RequestBody DecreaseHubInventoryRequest request) {
         List<FindHubInventoryResult> results =
-                hubInventoryCommandService.decreaseHubInventories(request.toCommand(), INTERNAL_SYSTEM);
+                hubInventoryCommandService.decreaseHubInventories(request.toCommand(), null);
 
         return CommonResponse.success(DecreaseHubInventoriesResponse.from(results));
     }
@@ -49,7 +48,7 @@ public class HubInventoryInternalController {
             @Valid @RequestBody DecreaseHubInventoriesByProductRequest request
     ) {
         DecreaseHubInventoriesByProductResult result =
-                hubInventoryCommandService.decreaseHubInventoriesByProduct(request.toCommand(), INTERNAL_SYSTEM);
+                hubInventoryCommandService.decreaseHubInventoriesByProduct(request.toCommand(), null);
 
         return CommonResponse.success(DecreaseHubInventoriesByProductResponse.from(result));
     }
@@ -57,7 +56,7 @@ public class HubInventoryInternalController {
     // 재고 복원
     @PatchMapping("/restoration")
     public CommonResponse<Void> restoreHubInventory(@Valid @RequestBody RestoreHubInventoryRequest request) {
-        hubInventoryCommandService.restoreHubInventories(request.toCommand(), INTERNAL_SYSTEM);
+        hubInventoryCommandService.restoreHubInventories(request.toCommand(), null);
         return CommonResponse.success(null);
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
@@ -47,7 +47,7 @@ public class HubInventoryInternalController {
             @Valid @RequestBody DecreaseHubInventoriesByProductRequest request
     ) {
         DecreaseHubInventoriesByProductResult result =
-                hubInventoryCommandService.decreaseHubInventoriesByProductResult(request.toCommand(), null);
+                hubInventoryCommandService.decreaseHubInventoriesByProduct(request.toCommand(), null);
 
         return ResponseEntity.ok(DecreaseHubInventoriesByProductResponse.from(result));
     }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
@@ -6,6 +6,7 @@ import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInvento
 import com.fhsh.daitda.hubservice.hubinventory.application.service.command.HubInventoryCommandService;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request.DecreaseHubInventoryRequest;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request.RestoreHubInventoryRequest;
+import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response.DecreaseHubInventoriesResponse;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response.FindHubInventoryResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/internal/v1/hub-inventories")
@@ -26,15 +29,11 @@ public class HubInventoryInternalController {
 
     // 재고 차감
     @PatchMapping("/decrease")
-    public ResponseEntity<FindHubInventoryResponse> decreaseHubInventory(@Valid @RequestBody DecreaseHubInventoryRequest request) {
-        DecreaseHubInventoryCommand command = DecreaseHubInventoryCommand.builder()
-                .hubInventoryId(request.getHubInventoryId())
-                .quantity(request.getQuantity())
-                .build();
+    public ResponseEntity<DecreaseHubInventoriesResponse> decreaseHubInventory(@Valid @RequestBody DecreaseHubInventoryRequest request) {
+        List<FindHubInventoryResult> results =
+                hubInventoryCommandService.decreaseHubInventories(request.toCommand(), null);
 
-        FindHubInventoryResult result = hubInventoryCommandService.decreaseHubInventory(command, null);
-
-        return ResponseEntity.ok(FindHubInventoryResponse.from(result));
+        return ResponseEntity.ok(DecreaseHubInventoriesResponse.from(results));
     }
 
     // 재고 복원

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
@@ -2,10 +2,13 @@ package com.fhsh.daitda.hubservice.hubinventory.presentation.controller.internal
 
 import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.RestoreHubInventoryCommand;
+import com.fhsh.daitda.hubservice.hubinventory.application.result.DecreaseHubInventoriesByProductResult;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
 import com.fhsh.daitda.hubservice.hubinventory.application.service.command.HubInventoryCommandService;
+import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request.DecreaseHubInventoriesByProductRequest;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request.DecreaseHubInventoryRequest;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request.RestoreHubInventoryRequest;
+import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response.DecreaseHubInventoriesByProductResponse;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response.DecreaseHubInventoriesResponse;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response.FindHubInventoryResponse;
 import jakarta.validation.Valid;
@@ -34,6 +37,22 @@ public class HubInventoryInternalController {
                 hubInventoryCommandService.decreaseHubInventories(request.toCommand(), null);
 
         return ResponseEntity.ok(DecreaseHubInventoriesResponse.from(results));
+    }
+
+    /**
+     * 주문 생성용 재고 차감 API
+     * supplierCompanyId + productId 기준으로 재고 row 조회
+     * 수량 차감
+     * 실제 사용한 hubInventoryId 반환
+     */
+    @PatchMapping("/decrease-by-product")
+    public ResponseEntity<DecreaseHubInventoriesByProductResponse> decreaseHubInventoriesByProduct(
+            @Valid @RequestBody DecreaseHubInventoriesByProductRequest request
+    ) {
+        DecreaseHubInventoriesByProductResult result =
+                hubInventoryCommandService.decreaseHubInventoriesByProductResult(request.toCommand(), null);
+
+        return ResponseEntity.ok(DecreaseHubInventoriesByProductResponse.from(result));
     }
 
     // 재고 복원

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/controller/internal/HubInventoryInternalController.java
@@ -8,8 +8,8 @@ import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request.Decrease
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request.RestoreHubInventoryRequest;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response.DecreaseHubInventoriesByProductResponse;
 import com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response.DecreaseHubInventoriesResponse;
+import com.fhsh.daitda.response.CommonResponse;
 import jakarta.validation.Valid;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +21,8 @@ import java.util.List;
 @RequestMapping("/internal/v1/hub-inventories")
 public class HubInventoryInternalController {
 
+    private static final String INTERNAL_SYSTEM = "SYSTEM";
+
     private final HubInventoryCommandService hubInventoryCommandService;
 
     public HubInventoryInternalController(HubInventoryCommandService hubInventoryCommandService) {
@@ -29,11 +31,11 @@ public class HubInventoryInternalController {
 
     // 재고 차감
     @PatchMapping("/decrease")
-    public ResponseEntity<DecreaseHubInventoriesResponse> decreaseHubInventory(@Valid @RequestBody DecreaseHubInventoryRequest request) {
+    public CommonResponse<DecreaseHubInventoriesResponse> decreaseHubInventory(@Valid @RequestBody DecreaseHubInventoryRequest request) {
         List<FindHubInventoryResult> results =
-                hubInventoryCommandService.decreaseHubInventories(request.toCommand(), null);
+                hubInventoryCommandService.decreaseHubInventories(request.toCommand(), INTERNAL_SYSTEM);
 
-        return ResponseEntity.ok(DecreaseHubInventoriesResponse.from(results));
+        return CommonResponse.success(DecreaseHubInventoriesResponse.from(results));
     }
 
     /**
@@ -43,19 +45,19 @@ public class HubInventoryInternalController {
      * 실제 사용한 hubInventoryId 반환
      */
     @PatchMapping("/decrease-by-product")
-    public ResponseEntity<DecreaseHubInventoriesByProductResponse> decreaseHubInventoriesByProduct(
+    public CommonResponse<DecreaseHubInventoriesByProductResponse> decreaseHubInventoriesByProduct(
             @Valid @RequestBody DecreaseHubInventoriesByProductRequest request
     ) {
         DecreaseHubInventoriesByProductResult result =
-                hubInventoryCommandService.decreaseHubInventoriesByProduct(request.toCommand(), null);
+                hubInventoryCommandService.decreaseHubInventoriesByProduct(request.toCommand(), INTERNAL_SYSTEM);
 
-        return ResponseEntity.ok(DecreaseHubInventoriesByProductResponse.from(result));
+        return CommonResponse.success(DecreaseHubInventoriesByProductResponse.from(result));
     }
 
     // 재고 복원
     @PatchMapping("/restoration")
-    public ResponseEntity<Void> restoreHubInventory(@Valid @RequestBody RestoreHubInventoryRequest request) {
-        hubInventoryCommandService.restoreHubInventories(request.toCommand(), null);
-        return ResponseEntity.ok().build();
+    public CommonResponse<Void> restoreHubInventory(@Valid @RequestBody RestoreHubInventoryRequest request) {
+        hubInventoryCommandService.restoreHubInventories(request.toCommand(), INTERNAL_SYSTEM);
+        return CommonResponse.success(null);
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/DecreaseHubInventoriesByProductRequest.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/DecreaseHubInventoriesByProductRequest.java
@@ -1,0 +1,46 @@
+package com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request;
+
+import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoriesByProductCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+public class DecreaseHubInventoriesByProductRequest {
+
+    // 공급 업체 회사 ID
+    @NotNull(message = "공급 업체 ID는 필수입니다.")
+    private UUID supplierCompanyId;
+
+    // 주문 항목 목록
+    @Valid
+    @NotEmpty(message = "주문 항목은 최소 1개 이상이어야 합니다.")
+    private List<Item> orderItems;
+
+    public DecreaseHubInventoriesByProductCommand toCommand() {
+        return DecreaseHubInventoriesByProductCommand.builder()
+                .supplierCompanyId(supplierCompanyId)
+                .orderItems(orderItems.stream()
+                        .map(item -> DecreaseHubInventoriesByProductCommand.Item.builder()
+                                .productId(item.getProductId())
+                                .quantity(item.getQuantity())
+                                .build())
+                        .toList())
+                .build();
+    }
+    @Getter
+    public static class Item {
+
+        @NotNull(message = "상품 ID는 필수입니다.")
+        private UUID productId;
+
+        @NotNull(message = "차감 수량은 필수입니다.")
+        @Min(value = 1, message = "차감 수량은 1 이상이어야 합니다.")
+        private Integer quantity;
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/DecreaseHubInventoriesByProductRequest.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/DecreaseHubInventoriesByProductRequest.java
@@ -20,7 +20,7 @@ public class DecreaseHubInventoriesByProductRequest {
     // 주문 항목 목록
     @Valid
     @NotEmpty(message = "주문 항목은 최소 1개 이상이어야 합니다.")
-    private List<Item> orderItems;
+    private List<@NotNull(message = "주문 항목에 null 요소를 포함할 수 없습니다.") @Valid Item> orderItems;
 
     public DecreaseHubInventoriesByProductCommand toCommand() {
         return DecreaseHubInventoriesByProductCommand.builder()

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/DecreaseHubInventoryRequest.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/DecreaseHubInventoryRequest.java
@@ -1,18 +1,41 @@
 package com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request;
 
+import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoriesCommand;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.UUID;
 
 @Getter
 public class DecreaseHubInventoryRequest {
 
-    @NotNull(message = "재고 ID는 필수입니다.")
-    private UUID hubInventoryId;
+    @Valid
+    @NotEmpty(message = "차감 항목은 최소 1개 이상이어야 합니다.")
+    private List<Item> items;
 
-    @NotNull(message = "차감 수량은 필수입니다.")
-    @Min(value = 1, message = "차감 수량은 1 이상이어야 합니다.")
-    private Integer quantity;
+    public DecreaseHubInventoriesCommand toCommand() {
+        return DecreaseHubInventoriesCommand.builder()
+                .items(items.stream()
+                        .map(item -> DecreaseHubInventoriesCommand.Item.builder()
+                                .hubInventoryId(item.getHubInventoryId())
+                                .quantity(item.getQuantity())
+                                .build())
+                        .toList())
+                .build();
+    }
+
+    @Getter
+    public static class Item {
+
+        @NotNull(message = "재고 ID는 필수입니다.")
+        private UUID hubInventoryId;
+
+        @NotNull(message = "차감 수량은 필수입니다.")
+        @Min(value = 1, message = "차감 수량은 1 이상이어야 합니다.")
+        private Integer quantity;
+    }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/RestoreHubInventoryRequest.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/RestoreHubInventoryRequest.java
@@ -15,7 +15,7 @@ public class RestoreHubInventoryRequest {
 
     @Valid
     @NotEmpty(message = "복원 항목은 최소 1개 이상이어야 합니다.")
-    private List<Item> orderItems;
+    private List<@NotNull(message = "복원 항목에 null 요소를 포함할 수 없습니다.") @Valid Item> orderItems;
 
     public RestoreHubInventoriesCommand toCommand() {
         return RestoreHubInventoriesCommand.builder()

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/RestoreHubInventoryRequest.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/RestoreHubInventoryRequest.java
@@ -1,18 +1,43 @@
 package com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request;
 
+import com.fhsh.daitda.hubservice.hubinventory.application.command.RestoreHubInventoryCommand;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.UUID;
 
 @Getter
 public class RestoreHubInventoryRequest {
 
-    @NotNull(message = "허브 재고 ID는 필수입니다.")
-    private UUID hubInventoryId;
+    @Valid
+    @NotEmpty(message = "복원 항목은 최소 1개 이상이어야 합니다.")
+    private List<Item> orderItems;
 
-    @NotNull(message = "복원 수량은 필수입니다.")
-    @Min(value = 1, message = "복원 수량은 1 이상이어야 합니다.")
-    private Integer quantity;
+    public RestoreHubInventoryCommand toCommand() {
+        return RestoreHubInventoryCommand.builder()
+                .orderItems(orderItems.stream()
+                        .map(item -> RestoreHubInventoryCommand.Item.builder()
+                                .hubInventoryId(item.getHubInventoryId())
+                                .quantity(item.getQuantity())
+                                .build())
+                        .toList())
+                .build();
+    }
+
+    // 개별 복원 항목
+    @Getter
+    public static class Item{
+
+        @NotNull(message = "허브 재고 ID는 필수입니다.")
+        private UUID hubInventoryId;
+
+        @NotNull(message = "복원 수량은 필수입니다.")
+        @Min(value = 1, message = "복원 수량은 1 이상이어야 합니다.")
+        private Integer quantity;
+
+    }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/RestoreHubInventoryRequest.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/request/RestoreHubInventoryRequest.java
@@ -1,6 +1,6 @@
 package com.fhsh.daitda.hubservice.hubinventory.presentation.dto.request;
 
-import com.fhsh.daitda.hubservice.hubinventory.application.command.RestoreHubInventoryCommand;
+import com.fhsh.daitda.hubservice.hubinventory.application.command.RestoreHubInventoriesCommand;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
@@ -17,10 +17,10 @@ public class RestoreHubInventoryRequest {
     @NotEmpty(message = "복원 항목은 최소 1개 이상이어야 합니다.")
     private List<Item> orderItems;
 
-    public RestoreHubInventoryCommand toCommand() {
-        return RestoreHubInventoryCommand.builder()
+    public RestoreHubInventoriesCommand toCommand() {
+        return RestoreHubInventoriesCommand.builder()
                 .orderItems(orderItems.stream()
-                        .map(item -> RestoreHubInventoryCommand.Item.builder()
+                        .map(item -> RestoreHubInventoriesCommand.Item.builder()
                                 .hubInventoryId(item.getHubInventoryId())
                                 .quantity(item.getQuantity())
                                 .build())

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/response/DecreaseHubInventoriesByProductResponse.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/response/DecreaseHubInventoriesByProductResponse.java
@@ -1,0 +1,34 @@
+package com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response;
+
+import com.fhsh.daitda.hubservice.hubinventory.application.result.DecreaseHubInventoriesByProductResult;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+// 주문 생성용 재고 차감 응답 DTO
+@Getter
+@Builder
+public class DecreaseHubInventoriesByProductResponse {
+
+    private List<Item> items;
+
+    public static DecreaseHubInventoriesByProductResponse from(DecreaseHubInventoriesByProductResult result) {
+        return DecreaseHubInventoriesByProductResponse.builder()
+                .items(result.getItems().stream()
+                        .map(item -> Item.builder()
+                                .hubInventoryId(item.getHubInventoryId())
+                                .productId(item.getProductId())
+                                .build())
+                        .toList())
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class Item {
+        private UUID hubInventoryId;
+        private UUID productId;
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/response/DecreaseHubInventoriesResponse.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/response/DecreaseHubInventoriesResponse.java
@@ -1,0 +1,39 @@
+package com.fhsh.daitda.hubservice.hubinventory.presentation.dto.response;
+
+import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class DecreaseHubInventoriesResponse {
+
+    private List<Item> items;
+
+    public static DecreaseHubInventoriesResponse from(List<FindHubInventoryResult> results) {
+        return DecreaseHubInventoriesResponse.builder()
+                .items(results.stream()
+                        .map(findHubInventoryResult -> Item.builder()
+                                .hubInventoryId(findHubInventoryResult.hubInventoryId())
+                                .hubInventoryId(findHubInventoryResult.hubId())
+                                .companyId(findHubInventoryResult.companyId())
+                                .productId(findHubInventoryResult.productId())
+                                .quantity(findHubInventoryResult.quantity())
+                                .build())
+                        .toList())
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class Item{
+        private UUID hubInventoryId;
+        private UUID hubId;
+        private UUID companyId;
+        private UUID productId;
+        private Integer quantity;
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/response/DecreaseHubInventoriesResponse.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubinventory/presentation/dto/response/DecreaseHubInventoriesResponse.java
@@ -18,7 +18,7 @@ public class DecreaseHubInventoriesResponse {
                 .items(results.stream()
                         .map(findHubInventoryResult -> Item.builder()
                                 .hubInventoryId(findHubInventoryResult.hubInventoryId())
-                                .hubInventoryId(findHubInventoryResult.hubId())
+                                .hubId(findHubInventoryResult.hubId())
                                 .companyId(findHubInventoryResult.companyId())
                                 .productId(findHubInventoryResult.productId())
                                 .quantity(findHubInventoryResult.quantity())

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/command/HubRouteCommandService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/command/HubRouteCommandService.java
@@ -31,7 +31,7 @@ public class HubRouteCommandService {
 
     // 허브 경로 생성
     @Transactional
-    public FindHubRouteResult createHubRoute(CreateHubRouteCommand command, String createdBy) {
+    public FindHubRouteResult createHubRoute(CreateHubRouteCommand command, UUID createdBy) {
         findActiveHub(command.getSrcHubId());
         findActiveHub(command.getDestHubId());
         validateDuplicateHubRoute(command.getSrcHubId(), command.getDestHubId());
@@ -57,7 +57,7 @@ public class HubRouteCommandService {
 
     // 허브 경로 정보 수정
     @Transactional
-    public FindHubRouteResult updateHubRoute(UUID hubRouteId, UpdateHubRouteCommand command, String updatedBy) {
+    public FindHubRouteResult updateHubRoute(UUID hubRouteId, UpdateHubRouteCommand command, UUID updatedBy) {
         HubRoute hubRoute = findActiveHubRoute(hubRouteId);
 
         hubRoute.updateRouteInfo(
@@ -71,7 +71,7 @@ public class HubRouteCommandService {
 
     // 허브 경로 논리 삭제
     @Transactional
-    public void deleteHubRoute(UUID hubRouteId, String deletedBy) {
+    public void deleteHubRoute(UUID hubRouteId, UUID deletedBy) {
         HubRoute hubRoute = findActiveHubRoute(hubRouteId);
         hubRoute.softDelete(deletedBy);
     }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
@@ -9,12 +9,17 @@ import com.fhsh.daitda.hubservice.hubroute.domain.repository.HubRouteRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.UUID;
+import java.math.BigDecimal;
+import java.util.*;
 
 @Service
 @Transactional(readOnly = true)
 public class HubRouteQueryService {
+
+    /**
+     * 릴레이 배송으로 전환할 기준 거리
+     */
+    private static final BigDecimal RELAY_THRESHOLD_KM = new BigDecimal("200");
 
     private final HubRouteRepository hubRouteRepository;
 
@@ -22,6 +27,7 @@ public class HubRouteQueryService {
         this.hubRouteRepository = hubRouteRepository;
     }
 
+    // 삭제되지 않은 전체 허브 경로 목록 조회
     public List<ListHubRouteResult> getHubRoutes() {
         return hubRouteRepository.findAllByDeletedAtIsNull()
                 .stream()
@@ -29,11 +35,13 @@ public class HubRouteQueryService {
                 .toList();
     }
 
+    // 허브 경로 ID 기준으로 단건 경로 조회
     public FindHubRouteResult getHubRoute(UUID hubRouteId) {
         HubRoute hubRoute = findActiveHubRoute(hubRouteId);
         return FindHubRouteResult.from(hubRoute);
     }
 
+    //  출발 허브와 도착 허브 조합으로 개별 구간 route를 조회
     public FindHubRouteResult searchHubRoute(UUID srcHubId, UUID destHubId) {
         HubRoute hubRoute = hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(srcHubId, destHubId)
                 .orElseThrow(() -> new BusinessException(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND));
@@ -41,8 +49,162 @@ public class HubRouteQueryService {
         return FindHubRouteResult.from(hubRoute);
     }
 
+    /**
+     * 최종 배송 경로(path)를 조회
+     *
+     * 정책:
+     * - 직행 route가 존재하고 거리가 200km 미만이면 1개짜리 리스트 반환
+     * - 직행 route가 200km 이상이거나 직행 route가 없으면 릴레이 경로를 계산해서 리스트 반환
+     */
+    public List<FindHubRouteResult> getHubRoutePath(UUID srcHubId, UUID destHubId) {
+        validateDifferentHub(srcHubId, destHubId);
+
+        Optional<HubRoute> directRoute = hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(srcHubId, destHubId);
+
+        if (directRoute.isPresent() && directRoute.get().getDistance().compareTo(RELAY_THRESHOLD_KM) < 0) {
+            return List.of(FindHubRouteResult.from(directRoute.get()));
+        }
+
+        return findRelayPath(srcHubId, destHubId).stream()
+                .map(hubRoute -> FindHubRouteResult.from(hubRoute))
+                .toList();
+    }
+
+    /**
+     * 릴레이 경로를 계산
+     *
+     * active route를 그래프로 보는 이유
+     * - hub_route row는 개별 구간 edge 역할을 하기 때문
+     * - 최종 배송 경로(path)는 여러 edge를 이어 붙인 결과이기 때문
+     *
+     * 다익스트라를 쓰는 이유:
+     * - distance가 가중치인 최단 경로 문제로 볼 수 있기 때문
+     * - 현재 요구사항에서는 가장 자연스럽고 구현도 안정적인 방식이기 때문
+     */
+    private List<HubRoute> findRelayPath(UUID srcHubId, UUID destHubId) {
+        List<HubRoute> routes = hubRouteRepository.findAllByDeletedAtIsNull();
+
+        Map<UUID, List<HubRoute>> graph = buildGraph(routes);
+        Map<UUID, BigDecimal> distanceMap = new HashMap<>();
+        Map<UUID, HubRoute> previousRouteMap = new HashMap<>();
+
+        PriorityQueue<RouteNode> pq = new PriorityQueue<>((o1, o2) ->
+            o1.distance().compareTo(o2.distance)
+        );
+
+        distanceMap.put(srcHubId, BigDecimal.ZERO);
+        pq.offer(new RouteNode(srcHubId, BigDecimal.ZERO));
+
+        while (!pq.isEmpty()) {
+            RouteNode current = pq.poll();
+
+            BigDecimal knownDistance = distanceMap.getOrDefault(
+                    current.hubId,
+                    BigDecimal.valueOf(Double.MAX_VALUE)
+            );
+
+            if (current.distance().compareTo(knownDistance) > 0) {
+                continue;
+            }
+
+            if (current.hubId().equals(destHubId)) {
+                break;
+            }
+
+            List<HubRoute> nextRoutes = graph.getOrDefault(current.hubId, Collections.emptyList());
+
+            for (HubRoute nextRoute : nextRoutes) {
+                UUID nextHubId = nextRoute.getDestHubId();
+                BigDecimal nextDistance = current.distance().add(nextRoute.getDistance());
+
+                BigDecimal recordedDistance = distanceMap.get(nextHubId);
+
+                if (recordedDistance == null || nextDistance.compareTo(recordedDistance) < 0) {
+                    distanceMap.put(nextHubId, nextDistance);
+                    previousRouteMap.put(nextHubId, nextRoute);
+                    pq.offer(new RouteNode(nextHubId, nextDistance));
+                }
+            }
+        }
+
+        if (!previousRouteMap.containsKey(destHubId)) {
+            throw new BusinessException(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND);
+        }
+        return reconstructPath(previousRouteMap, srcHubId, destHubId);
+    }
+
+    /**
+     * active route row들을 src 기준 그래프 형태로 변환
+     *
+     * 기능:
+     * - key: 출발 허브 ID
+     * - value: 그 허브에서 출발하는 route 목록
+     *
+     * 예시:
+     * - 서울 -> 대전
+     * - 서울 -> 강릉
+     *
+     * 그러면 graph.get(서울) 은
+     * [서울->대전, 서울->강릉]
+     *
+     * 별도 메서드로 분리한 이유
+     * - path 계산 로직 본문이 너무 길어지지 않게 하기 위해
+     * - "route 목록을 그래프로 본다"는 의도를 메서드 이름으로 드러내기 위해
+     */
+    private Map<UUID, List<HubRoute>> buildGraph(List<HubRoute> routes) {
+        Map<UUID, List<HubRoute>> graph = new HashMap<>();
+
+        for (HubRoute route : routes) {
+            graph.computeIfAbsent(route.getSrcHubId(), Key -> new ArrayList<>()).add(route);
+        }
+        return graph;
+    }
+
+    private List<HubRoute> reconstructPath(Map<UUID, HubRoute> previousRouteMap,
+                                           UUID srcHubId,
+                                           UUID destHubId)
+    {
+        List<HubRoute> path = new ArrayList<>();
+        UUID currentHubId = destHubId;
+
+        while (!currentHubId.equals(srcHubId)) {
+            HubRoute route = previousRouteMap.get(currentHubId);
+
+            if (route == null) {
+                throw new BusinessException(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND);
+            }
+
+            path.add(route);
+            currentHubId = route.getSrcHubId();
+        }
+
+        Collections.reverse(path);
+        return path;
+    }
+
+    private void validateDifferentHub(UUID srcHubId, UUID destHubId) {
+        if (srcHubId.equals(destHubId)) {
+            throw new IllegalArgumentException("출발 허브와 도착 허브는 같을 수 없습니다.");
+        }
+    }
+
     private HubRoute findActiveHubRoute(UUID hubRouteId) {
         return hubRouteRepository.findByHubRouteIdAndDeletedAtIsNull(hubRouteId)
                 .orElseThrow(() -> new BusinessException(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND));
+    }
+
+    /**
+     * 우선순위 큐에 넣을 노드
+     *
+     * hubId:
+     * - 현재 도착해 있는 허브
+     *
+     * distance:
+     * - 출발 허브부터 현재 허브까지 누적 거리
+     *
+     * 필요한 이유:
+     * - 다익스트라에서 "가장 짧은 후보부터 먼저 처리"해야 하기 때문
+     */
+    private record RouteNode(UUID hubId, BigDecimal distance) {
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
@@ -187,6 +187,10 @@ public class HubRouteQueryService {
     }
 
     private void validateDifferentHub(UUID srcHubId, UUID destHubId) {
+        if (srcHubId == null || destHubId == null) {
+            throw new IllegalArgumentException("출발 허브와 도착 허브는 필수입니다.");
+        }
+
         if (srcHubId.equals(destHubId)) {
             throw new IllegalArgumentException("출발 허브와 도착 허브는 같을 수 없습니다.");
         }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
@@ -93,7 +93,7 @@ public class HubRouteQueryService {
         Map<UUID, HubRoute> previousRouteMap = new HashMap<>();
 
         PriorityQueue<RouteNode> pq = new PriorityQueue<>((o1, o2) ->
-            o1.distance().compareTo(o2.distance)
+            o1.distance().compareTo(o2.distance())
         );
 
         distanceMap.put(srcHubId, BigDecimal.ZERO);
@@ -103,7 +103,7 @@ public class HubRouteQueryService {
             RouteNode current = pq.poll();
 
             BigDecimal knownDistance = distanceMap.getOrDefault(
-                    current.hubId,
+                    current.hubId(),
                     BigDecimal.valueOf(Double.MAX_VALUE)
             );
 
@@ -115,7 +115,7 @@ public class HubRouteQueryService {
                 break;
             }
 
-            List<HubRoute> nextRoutes = graph.getOrDefault(current.hubId, Collections.emptyList());
+            List<HubRoute> nextRoutes = graph.getOrDefault(current.hubId(), Collections.emptyList());
 
             for (HubRoute nextRoute : nextRoutes) {
                 UUID nextHubId = nextRoute.getDestHubId();
@@ -159,7 +159,7 @@ public class HubRouteQueryService {
         Map<UUID, List<HubRoute>> graph = new HashMap<>();
 
         for (HubRoute route : routes) {
-            graph.computeIfAbsent(route.getSrcHubId(), Key -> new ArrayList<>()).add(route);
+            graph.computeIfAbsent(route.getSrcHubId(), key -> new ArrayList<>()).add(route);
         }
         return graph;
     }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
@@ -84,7 +84,11 @@ public class HubRouteQueryService {
     private List<HubRoute> findRelayPath(UUID srcHubId, UUID destHubId) {
         List<HubRoute> routes = hubRouteRepository.findAllByDeletedAtIsNull();
 
-        Map<UUID, List<HubRoute>> graph = buildGraph(routes);
+        List<HubRoute> relayCandidates = routes.stream()
+                .filter(route -> !(route.getSrcHubId().equals(srcHubId) && route.getDestHubId().equals(destHubId)))
+                .toList();
+
+        Map<UUID, List<HubRoute>> graph = buildGraph(relayCandidates);
         Map<UUID, BigDecimal> distanceMap = new HashMap<>();
         Map<UUID, HubRoute> previousRouteMap = new HashMap<>();
 

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/domain/entity/HubRoute.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/domain/entity/HubRoute.java
@@ -46,7 +46,7 @@ public class HubRoute extends BaseUserEntity {
 
     public static HubRoute create(UUID srcHubId, UUID destHubId,
                                   Integer durationTime, BigDecimal distance,
-                                  String createdBy) {
+                                  UUID createdBy) {
         validateHubIds(srcHubId, destHubId);
         validateDurationTime(durationTime);
         validateDistance(distance);
@@ -69,7 +69,7 @@ public class HubRoute extends BaseUserEntity {
         }
     }
 
-    public void updateRouteInfo(Integer durationTime, BigDecimal distance, String updatedBy) {
+    public void updateRouteInfo(Integer durationTime, BigDecimal distance, UUID updatedBy) {
         validateDurationTime(durationTime);
         validateDistance(distance);
 
@@ -78,7 +78,7 @@ public class HubRoute extends BaseUserEntity {
         this.updatedBy = updatedBy;
     }
 
-    public void softDelete(String deletedBy) {
+    public void softDelete(UUID deletedBy) {
         delete(deletedBy);
     }
 

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/internal/HubRouteInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/internal/HubRouteInternalController.java
@@ -26,12 +26,12 @@ public class HubRouteInternalController {
      * 출발 허브와 도착 허브 조합으로 허브 경로 조회
      */
     @GetMapping
-    public FindHubRouteResponse getHubRoute(
+    public CommonResponse<FindHubRouteResponse> getHubRoute(
             @RequestParam UUID srcHubId,
             @RequestParam UUID destHubId
     ) {
         FindHubRouteResult result = hubRouteQueryService.searchHubRoute(srcHubId, destHubId);
-        return FindHubRouteResponse.from(result);
+        return CommonResponse.success(FindHubRouteResponse.from(result));
     }
 
     @GetMapping("/path")

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/internal/HubRouteInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/internal/HubRouteInternalController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -32,5 +33,14 @@ public class HubRouteInternalController {
         return FindHubRouteResponse.from(result);
     }
 
+    @GetMapping("/path")
+    public List<FindHubRouteResponse> getHubRoutePath(@RequestParam UUID srcHubId,
+                                                      @RequestParam UUID destHubId)
+    {
+        List<FindHubRouteResult> results = hubRouteQueryService.getHubRoutePath(srcHubId, destHubId);
 
+        return results.stream()
+                .map(result -> FindHubRouteResponse.from(result))
+                .toList();
+    }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/internal/HubRouteInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/internal/HubRouteInternalController.java
@@ -3,6 +3,7 @@ package com.fhsh.daitda.hubservice.hubroute.presentation.controller.internal;
 import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.application.service.query.HubRouteQueryService;
 import com.fhsh.daitda.hubservice.hubroute.presentation.dto.response.FindHubRouteResponse;
+import com.fhsh.daitda.response.CommonResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,13 +35,13 @@ public class HubRouteInternalController {
     }
 
     @GetMapping("/path")
-    public List<FindHubRouteResponse> getHubRoutePath(@RequestParam UUID srcHubId,
-                                                      @RequestParam UUID destHubId)
-    {
+    public CommonResponse<List<FindHubRouteResponse>> getHubRoutePath(@RequestParam UUID srcHubId, @RequestParam UUID destHubId) {
         List<FindHubRouteResult> results = hubRouteQueryService.getHubRoutePath(srcHubId, destHubId);
 
-        return results.stream()
+        List<FindHubRouteResponse> responses = results.stream()
                 .map(result -> FindHubRouteResponse.from(result))
                 .toList();
+
+        return CommonResponse.success(responses);
     }
 }

--- a/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryCommandServiceTest.java
@@ -28,7 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class HubInventoryServiceTest {
+public class HubInventoryCommandServiceTest {
 
     @Mock
     private HubInventoryRepository hubInventoryRepository;

--- a/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryCommandServiceTest.java
@@ -269,6 +269,41 @@ public class HubInventoryCommandServiceTest {
     }
 
     @Test
+    @DisplayName("회사와 상품 기준 조회 결과가 복수이면 주문 생성용 차감은 실패한다")
+    void 주문생성용_재고차감_실패_복수조회() {
+        // given
+        UUID supplierCompanyId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+
+        HubInventory inventory1 = HubInventory.create(HUB_ID, supplierCompanyId, productId, 100, USER_ID);
+        ReflectionTestUtils.invokeMethod(inventory1, "prePersist");
+        ReflectionTestUtils.setField(inventory1, "hubInventoryId", UUID.randomUUID());
+
+        HubInventory inventory2 = HubInventory.create(HUB_ID, supplierCompanyId, productId, 80, USER_ID);
+        ReflectionTestUtils.invokeMethod(inventory2, "prePersist");
+        ReflectionTestUtils.setField(inventory2, "hubInventoryId", UUID.randomUUID());
+
+        DecreaseHubInventoriesByProductCommand command = DecreaseHubInventoriesByProductCommand.builder()
+                .supplierCompanyId(supplierCompanyId)
+                .orderItems(List.of(
+                        DecreaseHubInventoriesByProductCommand.Item.builder()
+                                .productId(productId)
+                                .quantity(10)
+                                .build()
+                ))
+                .build();
+
+        when(hubInventoryRepository.findAllByCompanyIdAndProductIdAndDeletedAtIsNull(supplierCompanyId, productId))
+                .thenReturn(List.of(inventory1, inventory2));
+
+        // when & then
+        assertThatThrownBy(() -> hubInventoryCommandService.decreaseHubInventoriesByProduct(command, USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(HubInventoryErrorCode.HUB_INVENTORY_DUPLICATED_RESULT);
+    }
+
+    @Test
     @DisplayName("여러 재고를 한 번에 복원할 수 있다")
     void 여러재고_일괄복원성공() {
         // given

--- a/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryCommandServiceTest.java
@@ -40,7 +40,7 @@ public class HubInventoryCommandServiceTest {
     private static final UUID COMPANY_ID = UUID.randomUUID();
     private static final UUID PRODUCT_ID = UUID.randomUUID();
     private static final UUID HUB_INVENTORY_ID = UUID.randomUUID();
-    private static final String USER_ID = "test-user";
+    private static final UUID USER_ID = UUID.randomUUID();
 
     @Test
     @DisplayName("허브 재고 생성 성공")

--- a/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryCommandServiceTest.java
@@ -283,13 +283,13 @@ public class HubInventoryCommandServiceTest {
         ReflectionTestUtils.invokeMethod(inventory2, "prePersist");
         ReflectionTestUtils.setField(inventory2, "hubInventoryId", hubInventoryId2);
 
-        RestoreHubInventoryCommand command = RestoreHubInventoryCommand.builder()
+        RestoreHubInventoriesCommand command = RestoreHubInventoriesCommand.builder()
                 .orderItems(List.of(
-                        RestoreHubInventoryCommand.Item.builder()
+                        RestoreHubInventoriesCommand.Item.builder()
                                 .hubInventoryId(hubInventoryId1)
                                 .quantity(10)
                                 .build(),
-                        RestoreHubInventoryCommand.Item.builder()
+                        RestoreHubInventoriesCommand.Item.builder()
                                 .hubInventoryId(hubInventoryId2)
                                 .quantity(5)
                                 .build()
@@ -315,9 +315,9 @@ public class HubInventoryCommandServiceTest {
         // given
         UUID hubInventoryId = UUID.randomUUID();
 
-        RestoreHubInventoryCommand command = RestoreHubInventoryCommand.builder()
+        RestoreHubInventoriesCommand command = RestoreHubInventoriesCommand.builder()
                 .orderItems(List.of(
-                        RestoreHubInventoryCommand.Item.builder()
+                        RestoreHubInventoriesCommand.Item.builder()
                                 .hubInventoryId(hubInventoryId)
                                 .quantity(10)
                                 .build()

--- a/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryCommandServiceTest.java
@@ -221,10 +221,10 @@ public class HubInventoryCommandServiceTest {
                 ))
                 .build();
 
-        when(hubInventoryRepository.findByCompanyIdAndProductIdAndDeletedAtIsNull(supplierCompanyId, productId1))
-                .thenReturn(Optional.of(inventory1));
-        when(hubInventoryRepository.findByCompanyIdAndProductIdAndDeletedAtIsNull(supplierCompanyId, productId2))
-                .thenReturn(Optional.of(inventory2));
+        when(hubInventoryRepository.findAllByCompanyIdAndProductIdAndDeletedAtIsNull(supplierCompanyId, productId1))
+                .thenReturn(List.of(inventory1));
+        when(hubInventoryRepository.findAllByCompanyIdAndProductIdAndDeletedAtIsNull(supplierCompanyId, productId2))
+                .thenReturn(List.of(inventory2));
 
         // when
         DecreaseHubInventoriesByProductResult result =
@@ -258,8 +258,8 @@ public class HubInventoryCommandServiceTest {
                 ))
                 .build();
 
-        when(hubInventoryRepository.findByCompanyIdAndProductIdAndDeletedAtIsNull(supplierCompanyId, productId))
-                .thenReturn(Optional.empty());
+        when(hubInventoryRepository.findAllByCompanyIdAndProductIdAndDeletedAtIsNull(supplierCompanyId, productId))
+                .thenReturn(List.of());
 
         // when & then
         assertThatThrownBy(() -> hubInventoryCommandService.decreaseHubInventoriesByProduct(command, USER_ID))

--- a/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryServiceTest.java
@@ -2,8 +2,10 @@ package com.fhsh.daitda.hubservice.hubinventory.application.service;
 
 import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.CreateHubInventoryCommand;
+import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoriesByProductCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoriesCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoryCommand;
+import com.fhsh.daitda.hubservice.hubinventory.application.result.DecreaseHubInventoriesByProductResult;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
 import com.fhsh.daitda.hubservice.hubinventory.application.service.command.HubInventoryCommandService;
 import com.fhsh.daitda.hubservice.hubinventory.domain.entity.HubInventory;
@@ -188,6 +190,85 @@ public class HubInventoryServiceTest {
         assertThat(results).hasSize(2);
         assertThat(results.get(0).quantity()).isEqualTo(90);
         assertThat(results.get(1).quantity()).isEqualTo(45);
+    }
+
+    @Test
+    @DisplayName("회사와 상품 기준으로 재고를 찾아 주문 생성용 차감을 수행")
+    void 주문생성용_재고차감_성공() {
+        // given
+        UUID supplierCompanyId = UUID.randomUUID();
+        UUID productId1 = UUID.randomUUID();
+        UUID productId2 = UUID.randomUUID();
+        UUID hubInventoryId1 = UUID.randomUUID();
+        UUID hubInventoryId2 = UUID.randomUUID();
+
+        HubInventory inventory1 = HubInventory.create(HUB_ID, supplierCompanyId, productId1, 100, USER_ID);
+        ReflectionTestUtils.invokeMethod(inventory1, "prePersist");
+        ReflectionTestUtils.setField(inventory1, "hubInventoryId", hubInventoryId1);
+
+        HubInventory inventory2 = HubInventory.create(HUB_ID, supplierCompanyId, productId2, 50, USER_ID);
+        ReflectionTestUtils.invokeMethod(inventory2, "prePersist");
+        ReflectionTestUtils.setField(inventory2, "hubInventoryId", hubInventoryId2);
+
+        DecreaseHubInventoriesByProductCommand command = DecreaseHubInventoriesByProductCommand.builder()
+                .supplierCompanyId(supplierCompanyId)
+                .orderItems(List.of(
+                        DecreaseHubInventoriesByProductCommand.Item.builder()
+                                .productId(productId1)
+                                .quantity(10)
+                                .build(),
+                        DecreaseHubInventoriesByProductCommand.Item.builder()
+                                .productId(productId2)
+                                .quantity(5)
+                                .build()
+                ))
+                .build();
+
+        when(hubInventoryRepository.findByCompanyIdAndProductIdAndDeletedAtIsNull(supplierCompanyId, productId1))
+                .thenReturn(Optional.of(inventory1));
+        when(hubInventoryRepository.findByCompanyIdAndProductIdAndDeletedAtIsNull(supplierCompanyId, productId2))
+                .thenReturn(Optional.of(inventory2));
+
+        // when
+        DecreaseHubInventoriesByProductResult result =
+                hubInventoryCommandService.decreaseHubInventoriesByProduct(command, USER_ID);
+
+        // then
+        assertThat(result.getItems()).hasSize(2);
+        assertThat(result.getItems().get(0).getHubInventoryId()).isEqualTo(hubInventoryId1);
+        assertThat(result.getItems().get(0).getProductId()).isEqualTo(productId1);
+        assertThat(result.getItems().get(1).getHubInventoryId()).isEqualTo(hubInventoryId2);
+        assertThat(result.getItems().get(1).getProductId()).isEqualTo(productId2);
+
+        assertThat(inventory1.getQuantity()).isEqualTo(90);
+        assertThat(inventory2.getQuantity()).isEqualTo(45);
+    }
+
+    @Test
+    @DisplayName("회사와 상품 기준으로 재고를 찾지 못하면 주문 생성용 차감은 실패")
+    void 주문생성용_재고차감_실패_재고없음(){
+        // given
+        UUID supplierCompanyId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+
+        DecreaseHubInventoriesByProductCommand command = DecreaseHubInventoriesByProductCommand.builder()
+                .supplierCompanyId(supplierCompanyId)
+                .orderItems(List.of(
+                        DecreaseHubInventoriesByProductCommand.Item.builder()
+                                .productId(productId)
+                                .quantity(10)
+                                .build()
+                ))
+                .build();
+
+        when(hubInventoryRepository.findByCompanyIdAndProductIdAndDeletedAtIsNull(supplierCompanyId, productId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> hubInventoryCommandService.decreaseHubInventoriesByProduct(command, USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(HubInventoryErrorCode.HUB_INVENTORY_NOT_FOUND);
     }
 
     private HubInventory 생성된재고(int quantity) {

--- a/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryServiceTest.java
@@ -2,6 +2,7 @@ package com.fhsh.daitda.hubservice.hubinventory.application.service;
 
 import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.CreateHubInventoryCommand;
+import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoriesCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoryCommand;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
 import com.fhsh.daitda.hubservice.hubinventory.application.service.command.HubInventoryCommandService;
@@ -18,6 +19,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -144,6 +146,48 @@ public class HubInventoryServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(HubInventoryErrorCode.HUB_INVENTORY_CONFLICT);
+    }
+
+    @Test
+    @DisplayName("여러 재고를 한 번에 차감")
+    void 여러재고_일괄차감성공(){
+        // given
+        UUID HUB_INVENTORY_ID_1 = UUID.randomUUID();
+        UUID HUB_INVENTORY_ID_2 = UUID.randomUUID();
+
+        HubInventory inventory1 = HubInventory.create(HUB_ID, COMPANY_ID, PRODUCT_ID, 100, USER_ID);
+        ReflectionTestUtils.invokeMethod(inventory1, "prePersist");
+        ReflectionTestUtils.setField(inventory1, "hubInventoryId", HUB_INVENTORY_ID_1);
+
+        HubInventory inventory2 = HubInventory.create(HUB_ID, COMPANY_ID, UUID.randomUUID(), 50, USER_ID);
+        ReflectionTestUtils.invokeMethod(inventory2, "prePersist");
+        ReflectionTestUtils.setField(inventory2, "hubInventoryId", HUB_INVENTORY_ID_2);
+
+        DecreaseHubInventoriesCommand command = DecreaseHubInventoriesCommand.builder()
+                .items(List.of(
+                        DecreaseHubInventoriesCommand.Item.builder()
+                                .hubInventoryId(HUB_INVENTORY_ID_1)
+                                .quantity(10)
+                                .build(),
+                        DecreaseHubInventoriesCommand.Item.builder()
+                                .hubInventoryId(HUB_INVENTORY_ID_2)
+                                .quantity(5)
+                                .build()
+                ))
+                .build();
+
+        when(hubInventoryRepository.findByHubInventoryIdAndDeletedAtIsNull(HUB_INVENTORY_ID_1))
+                .thenReturn(Optional.of(inventory1));
+        when(hubInventoryRepository.findByHubInventoryIdAndDeletedAtIsNull(HUB_INVENTORY_ID_2))
+                .thenReturn(Optional.of(inventory2));
+
+        // when
+        List<FindHubInventoryResult> results = hubInventoryCommandService.decreaseHubInventories(command, USER_ID);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).quantity()).isEqualTo(90);
+        assertThat(results.get(1).quantity()).isEqualTo(45);
     }
 
     private HubInventory 생성된재고(int quantity) {

--- a/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubinventory/application/service/HubInventoryServiceTest.java
@@ -1,10 +1,7 @@
 package com.fhsh.daitda.hubservice.hubinventory.application.service;
 
 import com.fhsh.daitda.exception.BusinessException;
-import com.fhsh.daitda.hubservice.hubinventory.application.command.CreateHubInventoryCommand;
-import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoriesByProductCommand;
-import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoriesCommand;
-import com.fhsh.daitda.hubservice.hubinventory.application.command.DecreaseHubInventoryCommand;
+import com.fhsh.daitda.hubservice.hubinventory.application.command.*;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.DecreaseHubInventoriesByProductResult;
 import com.fhsh.daitda.hubservice.hubinventory.application.result.FindHubInventoryResult;
 import com.fhsh.daitda.hubservice.hubinventory.application.service.command.HubInventoryCommandService;
@@ -266,6 +263,72 @@ public class HubInventoryServiceTest {
 
         // when & then
         assertThatThrownBy(() -> hubInventoryCommandService.decreaseHubInventoriesByProduct(command, USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(HubInventoryErrorCode.HUB_INVENTORY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("여러 재고를 한 번에 복원할 수 있다")
+    void 여러재고_일괄복원성공() {
+        // given
+        UUID hubInventoryId1 = UUID.randomUUID();
+        UUID hubInventoryId2 = UUID.randomUUID();
+
+        HubInventory inventory1 = HubInventory.create(HUB_ID, COMPANY_ID, PRODUCT_ID, 90, USER_ID);
+        ReflectionTestUtils.invokeMethod(inventory1, "prePersist");
+        ReflectionTestUtils.setField(inventory1, "hubInventoryId", hubInventoryId1);
+
+        HubInventory inventory2 = HubInventory.create(HUB_ID, COMPANY_ID, UUID.randomUUID(), 45, USER_ID);
+        ReflectionTestUtils.invokeMethod(inventory2, "prePersist");
+        ReflectionTestUtils.setField(inventory2, "hubInventoryId", hubInventoryId2);
+
+        RestoreHubInventoryCommand command = RestoreHubInventoryCommand.builder()
+                .orderItems(List.of(
+                        RestoreHubInventoryCommand.Item.builder()
+                                .hubInventoryId(hubInventoryId1)
+                                .quantity(10)
+                                .build(),
+                        RestoreHubInventoryCommand.Item.builder()
+                                .hubInventoryId(hubInventoryId2)
+                                .quantity(5)
+                                .build()
+                ))
+                .build();
+
+        when(hubInventoryRepository.findByHubInventoryIdAndDeletedAtIsNull(hubInventoryId1))
+                .thenReturn(Optional.of(inventory1));
+        when(hubInventoryRepository.findByHubInventoryIdAndDeletedAtIsNull(hubInventoryId2))
+                .thenReturn(Optional.of(inventory2));
+
+        // when
+        hubInventoryCommandService.restoreHubInventories(command, USER_ID);
+
+        // then
+        assertThat(inventory1.getQuantity()).isEqualTo(100);
+        assertThat(inventory2.getQuantity()).isEqualTo(50);
+    }
+
+    @Test
+    @DisplayName("복원 대상 재고를 찾지 못하면 복원은 실패한다")
+    void 재고복원실패_대상없음() {
+        // given
+        UUID hubInventoryId = UUID.randomUUID();
+
+        RestoreHubInventoryCommand command = RestoreHubInventoryCommand.builder()
+                .orderItems(List.of(
+                        RestoreHubInventoryCommand.Item.builder()
+                                .hubInventoryId(hubInventoryId)
+                                .quantity(10)
+                                .build()
+                ))
+                .build();
+
+        when(hubInventoryRepository.findByHubInventoryIdAndDeletedAtIsNull(hubInventoryId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> hubInventoryCommandService.restoreHubInventories(command, USER_ID))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(HubInventoryErrorCode.HUB_INVENTORY_NOT_FOUND);

--- a/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/HubRouteServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/HubRouteServiceTest.java
@@ -45,7 +45,7 @@ public class HubRouteServiceTest {
     private static final UUID HUB_ROUTE_ID = UUID.randomUUID();
     private static final UUID SRC_HUB_ID = UUID.randomUUID();
     private static final UUID DEST_HUB_ID = UUID.randomUUID();
-    private static final String USER_ID = "test-user";
+    private static final UUID USER_ID = UUID.randomUUID();
 
     @Test
     @DisplayName("허브 경로 생성 성공")

--- a/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
@@ -82,6 +82,28 @@ public class HubRouteQueryServiceTest {
     }
 
     @Test
+    @DisplayName("직행 경로가 200km이면 릴레이 경로 리스트를 반환한다")
+    void 직행경로_200km_릴레이경로반환() {
+        HubRoute directRoute = 생성된경로(SRC_HUB_ID, DEST_HUB_ID, 180, "200.00");
+        HubRoute firstRelay = 생성된경로(SRC_HUB_ID, VIA_HUB_ID, 120, "120.00");
+        HubRoute secondRelay = 생성된경로(VIA_HUB_ID, DEST_HUB_ID, 70, "70.00");
+
+        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
+                .thenReturn(Optional.of(directRoute));
+
+        when(hubRouteRepository.findAllByDeletedAtIsNull())
+                .thenReturn(List.of(directRoute, firstRelay, secondRelay));
+
+        List<FindHubRouteResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
+
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
+        assertThat(results.get(0).destHubId()).isEqualTo(VIA_HUB_ID);
+        assertThat(results.get(1).srcHubId()).isEqualTo(VIA_HUB_ID);
+        assertThat(results.get(1).destHubId()).isEqualTo(DEST_HUB_ID);
+    }
+
+    @Test
     @DisplayName("직행 경로가 없더라도 릴레이 경로가 있으면 리스트를 반환한다")
     void 직행경로없음_릴레이경로반환() {
         // given

--- a/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
@@ -35,7 +35,7 @@ public class HubRouteQueryServiceTest {
     private static final UUID SRC_HUB_ID = UUID.randomUUID();
     private static final UUID DEST_HUB_ID = UUID.randomUUID();
     private static final UUID VIA_HUB_ID = UUID.randomUUID();
-    private static final String USER_ID = "test-user";
+    private static final UUID USER_ID = UUID.randomUUID();
 
     @Test
     @DisplayName("직행 경로가 200km 미만이면 1개짜리 리스트 반환")

--- a/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
@@ -1,0 +1,159 @@
+package com.fhsh.daitda.hubservice.hubroute.application.service.query;
+
+import com.fhsh.daitda.exception.BusinessException;
+import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRouteResult;
+import com.fhsh.daitda.hubservice.hubroute.domain.entity.HubRoute;
+import com.fhsh.daitda.hubservice.hubroute.domain.exception.HubRouteErrorCode;
+import com.fhsh.daitda.hubservice.hubroute.domain.repository.HubRouteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class HubRouteQueryServiceTest {
+
+    @Mock
+    private HubRouteRepository hubRouteRepository;
+
+    @InjectMocks
+    private HubRouteQueryService hubRouteQueryService;
+
+    private static final UUID SRC_HUB_ID = UUID.randomUUID();
+    private static final UUID DEST_HUB_ID = UUID.randomUUID();
+    private static final UUID VIA_HUB_ID = UUID.randomUUID();
+    private static final String USER_ID = "test-user";
+
+    @Test
+    @DisplayName("직행 경로가 200km 미만이면 1개짜리 리스트 반환")
+    void 직행경로_200km미만_리스트1건반환() {
+        // given
+        HubRoute directRoute = 생성된경로(SRC_HUB_ID, DEST_HUB_ID, 120, "150.00");
+
+        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
+                .thenReturn(Optional.of(directRoute));
+
+        // when
+        List<FindHubRouteResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
+
+        // then
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
+        assertThat(results.get(0).destHubId()).isEqualTo(DEST_HUB_ID);
+        assertThat(results.get(0).distance()).isEqualByComparingTo("150.00");
+    }
+
+    @Test
+    @DisplayName("직행 경로가 200km 이상이면 릴레이 경로 리스트를 반환한다")
+    void 직행경로_200km이상_릴레이경로반환() {
+        // given
+        HubRoute directRoute = 생성된경로(SRC_HUB_ID, DEST_HUB_ID, 240, "280.00");
+        HubRoute firstRelay = 생성된경로(SRC_HUB_ID, VIA_HUB_ID, 120, "160.00");
+        HubRoute secondRelay = 생성된경로(VIA_HUB_ID, DEST_HUB_ID, 90, "120.00");
+
+        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
+                .thenReturn(Optional.of(directRoute));
+
+        when(hubRouteRepository.findAllByDeletedAtIsNull())
+                .thenReturn(List.of(directRoute, firstRelay, secondRelay));
+
+        // when
+        List<FindHubRouteResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
+        assertThat(results.get(0).destHubId()).isEqualTo(VIA_HUB_ID);
+        assertThat(results.get(1).srcHubId()).isEqualTo(VIA_HUB_ID);
+        assertThat(results.get(1).destHubId()).isEqualTo(DEST_HUB_ID);
+    }
+
+    @Test
+    @DisplayName("직행 경로가 없더라도 릴레이 경로가 있으면 리스트를 반환한다")
+    void 직행경로없음_릴레이경로반환() {
+        // given
+        HubRoute firstRelay = 생성된경로(
+                SRC_HUB_ID,
+                VIA_HUB_ID,
+                120,
+                "160.00"
+        );
+
+        HubRoute secondRelay = 생성된경로(
+                VIA_HUB_ID,
+                DEST_HUB_ID,
+                90,
+                "120.00"
+        );
+
+        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
+                .thenReturn(Optional.empty());
+
+        when(hubRouteRepository.findAllByDeletedAtIsNull())
+                .thenReturn(List.of(firstRelay, secondRelay));
+
+        // when
+        List<FindHubRouteResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
+        assertThat(results.get(0).destHubId()).isEqualTo(VIA_HUB_ID);
+        assertThat(results.get(1).srcHubId()).isEqualTo(VIA_HUB_ID);
+        assertThat(results.get(1).destHubId()).isEqualTo(DEST_HUB_ID);
+    }
+
+    @Test
+    @DisplayName("출발 허브와 도착 허브가 같으면 예외 발생")
+    void 출발도착허브동일_예외() {
+        // when & then
+        assertThatThrownBy(() -> hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, SRC_HUB_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("출발 허브와 도착 허브는 같을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("직행도 없고 릴레이 경로도 없으면 예외가 발생")
+    void 경로없음_예외() {
+        // given
+        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
+                .thenReturn(Optional.empty());
+
+        when(hubRouteRepository.findAllByDeletedAtIsNull())
+                .thenReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND);
+    }
+
+    private HubRoute 생성된경로(UUID srcHubId, UUID destHubId, Integer durationTime, String distance) {
+        HubRoute hubRoute = HubRoute.create(
+                srcHubId,
+                destHubId,
+                durationTime,
+                new BigDecimal(distance),
+                USER_ID
+        );
+
+        ReflectionTestUtils.invokeMethod(hubRoute, "prePersist");
+        ReflectionTestUtils.setField(hubRoute, "createdAt", LocalDateTime.now());
+
+        return hubRoute;
+    }
+}


### PR DESCRIPTION
## 🌱 설명

hub-service의 남은 핵심 기능을 구현

이번 작업에서는 hub / hubinventory / hubroute 도메인의 internal / external API를 명세서 기준으로 정리
주문 생성 및 취소 흐름에 필요한 내부 재고 차감/복원 API와 허브 간 경로 조회 기능을 반영

또한 공통 모듈(common) 업데이트에 맞춰 internal 응답 규약을 CommonResponse 형태로 통일
감사 필드(audit) 타입 변경에 맞게 사용자 식별자 처리도 함께 정리

## 📌 관련 이슈

- close #25 
- 
## ✅ 주요 변경 사항

### hub
- hub command / query 구조 기반으로 CRUD API 정리
- internal 단건 허브 조회 API 추가
- internal 응답을 `CommonResponse<T>` 규약으로 통일

### hubinventory
- 허브 재고 생성 / 수정 / 삭제 기능 정리
- bulk direct decrease API 반영
  - `PATCH /internal/v1/hub-inventories/decrease`
- 주문 생성용 decrease-by-product API 추가
  - `PATCH /internal/v1/hub-inventories/decrease-by-product`
  - `supplierCompanyId + orderItems[].productId` 기준 재고 조회 후 차감
  - 실제 사용한 `hubInventoryId` 반환
- 주문 취소용 bulk restoration API 반영
  - `PATCH /internal/v1/hub-inventories/restoration`
- internal 응답을 `CommonResponse<T>` 규약으로 통일

### hubroute
- hubroute command / query 구조 정리
- 개별 구간 route 조회 API 유지
  - `GET /internal/v1/hub-routes`
- 최종 배송 경로(path) 조회 API 추가
  - `GET /internal/v1/hub-routes/path`
- 200km 미만은 직행 1구간 리스트,
  200km 이상은 relay 경로 리스트를 반환하도록 반영
- internal 응답을 `CommonResponse<T>` 규약으로 통일

### 공통 / 인증 / 감사 필드
- common 모듈 버전 업데이트
  - `0.1.4-SNAPSHOT`
- `AuthenticatedUser.userId`를 UUID로 변경
- 감사 필드(createdBy, updatedBy, deletedBy) UUID 타입에 맞게 수정
- internal API는 현재 사용자 전달 규약이 없으므로 audit actor를 null 기반으로 처리

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- 이번 PR은 네이버 지도 연동 전까지 필요한 hub-service 핵심 기능 구현을 마무리하는 목적의 작업
- 허브 간 이동 모델은 `P2P + Hub-to-Hub Relay` 기준으로 반영
- `hub_route`는 개별 구간 row를 관리
  실제 배송 경로는 internal path API에서 계산하는 구조로 분리
- 주문 생성 시에는 company/product 기준으로 재고 row를 찾고
  차감에 사용한 실제 `hubInventoryId`를 반환하여 이후 취소/복원 흐름에 활용할 수 있도록 했습니다
- 다음 단계에서는 Naver Maps 연동을 통해 허브 간 거리/소요시간 계산 및 경로 데이터 보강을 진행할 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내부 허브 조회 API 추가 (/internal/v1/hubs/{id})
  * 상품별 일괄 재고 차감 API 추가 (PATCH /decrease-by-product)
  * 배송 경로 조회에 경로(path) 계산 API 추가 (/path)

* **개선 사항**
  * 사용자 식별자 타입을 전체적으로 UUID로 통일
  * 재고 일괄 차감/복원 지원 및 복원 엔드포인트 경로 변경(/restoration)

* **테스트**
  * 허브 인벤토리·경로 관련 신규 단위 테스트 추가, 일부 기존 테스트 삭제

* **잡무**
  * 내부 공통 의존성 버전 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->