### PR TITLE
[feature]  enhance hub route responses and internal path query

### DIFF
--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRoutePathResult.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRoutePathResult.java
@@ -1,0 +1,48 @@
+package com.fhsh.daitda.hubservice.hubroute.application.result;
+
+import com.fhsh.daitda.hubservice.hub.domain.entity.Hub;
+import com.fhsh.daitda.hubservice.hubroute.domain.entity.HubRoute;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.UUID;
+
+public record FindHubRoutePathResult(
+        Integer sequence,
+        UUID hubRouteId,
+        UUID srcHubId,
+        String srcHubName,
+        String srcHubAddress,
+        UUID destHubId,
+        String destHubName,
+        String destHubAddress,
+        Integer durationTime,
+        String durationMinutes,
+        BigDecimal distance,
+        String distanceKm
+) {
+    public static FindHubRoutePathResult from(Integer sequence, HubRoute hubRoute, Hub srcHub, Hub destHub) {
+        return new FindHubRoutePathResult(
+                sequence,
+                hubRoute.getHubRouteId(),
+                hubRoute.getSrcHubId(),
+                srcHub.getHubName(),
+                srcHub.getHubAddress(),
+                hubRoute.getDestHubId(),
+                destHub.getHubName(),
+                destHub.getHubAddress(),
+                hubRoute.getDurationTime(),
+                toDurationMinutes(hubRoute.getDurationTime()),
+                hubRoute.getDistance(),
+                toDistanceKm(hubRoute.getDistance())
+        );
+    }
+
+    private static String toDurationMinutes(Integer durationTime) {
+        return durationTime + "분";
+    }
+
+    private static String toDistanceKm(BigDecimal distance) {
+        return distance.setScale(2, RoundingMode.HALF_UP).toPlainString() + "km";
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRouteResult.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRouteResult.java
@@ -23,27 +23,6 @@ public record FindHubRouteResult(
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-    /**
-     * create / update 응답과의 호환용
-     * - 아직 허브 상세를 붙이지 않는 경우 이름/주소는 null
-     */
-    public static FindHubRouteResult from(HubRoute hubRoute) {
-        return new FindHubRouteResult(
-                hubRoute.getHubRouteId(),
-                hubRoute.getSrcHubId(),
-                null,
-                null,
-                hubRoute.getDestHubId(),
-                null,
-                null,
-                hubRoute.getDurationTime(),
-                toDurationMinutes(hubRoute.getDurationTime()),
-                hubRoute.getDistance(),
-                toDistanceKm(hubRoute.getDistance()),
-                hubRoute.getCreatedAt(),
-                hubRoute.getUpdatedAt()
-        );
-    }
 
     public static FindHubRouteResult from(HubRoute hubRoute, Hub srcHub, Hub destHub) {
         return new FindHubRouteResult(

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRouteResult.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRouteResult.java
@@ -1,29 +1,73 @@
 package com.fhsh.daitda.hubservice.hubroute.application.result;
 
+import com.fhsh.daitda.hubservice.hub.domain.entity.Hub;
 import com.fhsh.daitda.hubservice.hubroute.domain.entity.HubRoute;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record FindHubRouteResult(
         UUID hubRouteId,
         UUID srcHubId,
+        String srcHubName,
+        String srcHubAddress,
         UUID destHubId,
+        String destHubName,
+        String destHubAddress,
         Integer durationTime,
+        String durationMinutes,
         BigDecimal distance,
+        String distanceKm,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
+    /**
+     * create / update 응답과의 호환용
+     * - 아직 허브 상세를 붙이지 않는 경우 이름/주소는 null
+     */
     public static FindHubRouteResult from(HubRoute hubRoute) {
         return new FindHubRouteResult(
                 hubRoute.getHubRouteId(),
                 hubRoute.getSrcHubId(),
+                null,
+                null,
                 hubRoute.getDestHubId(),
+                null,
+                null,
                 hubRoute.getDurationTime(),
+                toDurationMinutes(hubRoute.getDurationTime()),
                 hubRoute.getDistance(),
+                toDistanceKm(hubRoute.getDistance()),
                 hubRoute.getCreatedAt(),
                 hubRoute.getUpdatedAt()
         );
+    }
+
+    public static FindHubRouteResult from(HubRoute hubRoute, Hub srcHub, Hub destHub) {
+        return new FindHubRouteResult(
+                hubRoute.getHubRouteId(),
+                hubRoute.getSrcHubId(),
+                srcHub.getHubName(),
+                srcHub.getHubAddress(),
+                hubRoute.getDestHubId(),
+                destHub.getHubName(),
+                destHub.getHubAddress(),
+                hubRoute.getDurationTime(),
+                toDurationMinutes(hubRoute.getDurationTime()),
+                hubRoute.getDistance(),
+                toDistanceKm(hubRoute.getDistance()),
+                hubRoute.getCreatedAt(),
+                hubRoute.getUpdatedAt()
+        );
+    }
+
+    private static String toDurationMinutes(Integer durationTime) {
+        return durationTime + "분";
+    }
+
+    private static String toDistanceKm(BigDecimal distance) {
+        return distance.setScale(2, RoundingMode.HALF_UP).toPlainString() + "km";
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/command/HubRouteCommandService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/command/HubRouteCommandService.java
@@ -61,7 +61,7 @@ public class HubRouteCommandService {
 
         try {
             HubRoute savedHubRoute = hubRouteRepository.saveAndFlush(hubRoute);
-            return FindHubRouteResult.from(savedHubRoute);
+            return FindHubRouteResult.from(savedHubRoute, srcHub, destHub);
         } catch (DataIntegrityViolationException e) {
             if (isUniqueConstraintViolation(e)) {
                 throw new BusinessException(HubRouteErrorCode.HUB_ROUTE_CONFLICT);
@@ -69,7 +69,6 @@ public class HubRouteCommandService {
             throw e;
         }
     }
-
     // 허브 경로 정보 수정
     @Transactional
     public FindHubRouteResult updateHubRoute(UUID hubRouteId, UpdateHubRouteCommand command, UUID updatedBy) {
@@ -91,7 +90,7 @@ public class HubRouteCommandService {
                 updatedBy
         );
 
-        return FindHubRouteResult.from(hubRoute);
+        return FindHubRouteResult.from(hubRoute, srcHub, destHub);
     }
 
     // 허브 경로 논리 삭제

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
@@ -4,6 +4,7 @@ import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.hubservice.hub.domain.entity.Hub;
 import com.fhsh.daitda.hubservice.hub.domain.exception.HubErrorCode;
 import com.fhsh.daitda.hubservice.hub.domain.repository.HubRepository;
+import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRoutePathResult;
 import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.application.result.ListHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.domain.entity.HubRoute;
@@ -62,24 +63,34 @@ public class HubRouteQueryService {
      * - 직행 route가 존재하고 거리가 200km 미만이면 1개짜리 리스트 반환
      * - 직행 route가 200km 이상이거나 직행 route가 없으면 릴레이 경로를 계산해서 리스트 반환
      */
-    public List<FindHubRouteResult> getHubRoutePath(UUID srcHubId, UUID destHubId) {
+    public List<FindHubRoutePathResult> getHubRoutePath(UUID srcHubId, UUID destHubId) {
         validateDifferentHub(srcHubId, destHubId);
 
         Optional<HubRoute> directRoute = hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(srcHubId, destHubId);
 
         if (directRoute.isPresent() && directRoute.get().getDistance().compareTo(RELAY_THRESHOLD_KM) < 0) {
-            return List.of(toFindHubRouteResult(directRoute.get()));
+            return List.of(toFindHubRoutePathResult(1, directRoute.get()));
         }
 
-        return findRelayPath(srcHubId, destHubId).stream()
-                .map(this::toFindHubRouteResult)
-                .toList();
+        List<HubRoute> relayPath = findRelayPath(srcHubId, destHubId);
+
+        List<FindHubRoutePathResult> results = new ArrayList<>();
+        for (int i = 0; i < relayPath.size(); i++) {
+            results.add(toFindHubRoutePathResult(i + 1, relayPath.get(i)));
+        }
+        return results;
     }
 
     private FindHubRouteResult toFindHubRouteResult(HubRoute hubRoute) {
         Hub srcHub = findActiveHub(hubRoute.getSrcHubId());
         Hub destHub = findActiveHub(hubRoute.getDestHubId());
         return FindHubRouteResult.from(hubRoute, srcHub, destHub);
+    }
+
+    private FindHubRoutePathResult toFindHubRoutePathResult(Integer sequence, HubRoute hubRoute) {
+        Hub srcHub = findActiveHub(hubRoute.getSrcHubId());
+        Hub destHub = findActiveHub(hubRoute.getDestHubId());
+        return FindHubRoutePathResult.from(sequence, hubRoute, srcHub, destHub);
     }
 
     private Hub findActiveHub(UUID hubId) {

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
@@ -1,6 +1,9 @@
 package com.fhsh.daitda.hubservice.hubroute.application.service.query;
 
 import com.fhsh.daitda.exception.BusinessException;
+import com.fhsh.daitda.hubservice.hub.domain.entity.Hub;
+import com.fhsh.daitda.hubservice.hub.domain.exception.HubErrorCode;
+import com.fhsh.daitda.hubservice.hub.domain.repository.HubRepository;
 import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.application.result.ListHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.domain.entity.HubRoute;
@@ -22,31 +25,34 @@ public class HubRouteQueryService {
     private static final BigDecimal RELAY_THRESHOLD_KM = new BigDecimal("200");
 
     private final HubRouteRepository hubRouteRepository;
+    private final HubRepository hubRepository;
 
-    public HubRouteQueryService(HubRouteRepository hubRouteRepository) {
+    public HubRouteQueryService(HubRouteRepository hubRouteRepository,
+                                HubRepository hubRepository) {
         this.hubRouteRepository = hubRouteRepository;
+        this.hubRepository = hubRepository;
     }
 
     // 삭제되지 않은 전체 허브 경로 목록 조회
     public List<ListHubRouteResult> getHubRoutes() {
         return hubRouteRepository.findAllByDeletedAtIsNull()
                 .stream()
-                .map(hubRoute -> ListHubRouteResult.from(hubRoute))
+                .map(ListHubRouteResult::from)
                 .toList();
     }
 
     // 허브 경로 ID 기준으로 단건 경로 조회
     public FindHubRouteResult getHubRoute(UUID hubRouteId) {
         HubRoute hubRoute = findActiveHubRoute(hubRouteId);
-        return FindHubRouteResult.from(hubRoute);
+        return toFindHubRouteResult(hubRoute);
     }
 
-    //  출발 허브와 도착 허브 조합으로 개별 구간 route를 조회
+    // 출발 허브와 도착 허브 조합으로 개별 구간 route를 조회
     public FindHubRouteResult searchHubRoute(UUID srcHubId, UUID destHubId) {
         HubRoute hubRoute = hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(srcHubId, destHubId)
                 .orElseThrow(() -> new BusinessException(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND));
 
-        return FindHubRouteResult.from(hubRoute);
+        return toFindHubRouteResult(hubRoute);
     }
 
     /**
@@ -62,12 +68,23 @@ public class HubRouteQueryService {
         Optional<HubRoute> directRoute = hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(srcHubId, destHubId);
 
         if (directRoute.isPresent() && directRoute.get().getDistance().compareTo(RELAY_THRESHOLD_KM) < 0) {
-            return List.of(FindHubRouteResult.from(directRoute.get()));
+            return List.of(toFindHubRouteResult(directRoute.get()));
         }
 
         return findRelayPath(srcHubId, destHubId).stream()
-                .map(hubRoute -> FindHubRouteResult.from(hubRoute))
+                .map(this::toFindHubRouteResult)
                 .toList();
+    }
+
+    private FindHubRouteResult toFindHubRouteResult(HubRoute hubRoute) {
+        Hub srcHub = findActiveHub(hubRoute.getSrcHubId());
+        Hub destHub = findActiveHub(hubRoute.getDestHubId());
+        return FindHubRouteResult.from(hubRoute, srcHub, destHub);
+    }
+
+    private Hub findActiveHub(UUID hubId) {
+        return hubRepository.findByHubIdAndDeletedAtIsNull(hubId)
+                .orElseThrow(() -> new BusinessException(HubErrorCode.HUB_NOT_FOUND));
     }
 
     /**
@@ -93,7 +110,7 @@ public class HubRouteQueryService {
         Map<UUID, HubRoute> previousRouteMap = new HashMap<>();
 
         PriorityQueue<RouteNode> pq = new PriorityQueue<>((o1, o2) ->
-            o1.distance().compareTo(o2.distance())
+                o1.distance().compareTo(o2.distance())
         );
 
         distanceMap.put(srcHubId, BigDecimal.ZERO);
@@ -137,24 +154,6 @@ public class HubRouteQueryService {
         return reconstructPath(previousRouteMap, srcHubId, destHubId);
     }
 
-    /**
-     * active route row들을 src 기준 그래프 형태로 변환
-     *
-     * 기능:
-     * - key: 출발 허브 ID
-     * - value: 그 허브에서 출발하는 route 목록
-     *
-     * 예시:
-     * - 서울 -> 대전
-     * - 서울 -> 강릉
-     *
-     * 그러면 graph.get(서울) 은
-     * [서울->대전, 서울->강릉]
-     *
-     * 별도 메서드로 분리한 이유
-     * - path 계산 로직 본문이 너무 길어지지 않게 하기 위해
-     * - "route 목록을 그래프로 본다"는 의도를 메서드 이름으로 드러내기 위해
-     */
     private Map<UUID, List<HubRoute>> buildGraph(List<HubRoute> routes) {
         Map<UUID, List<HubRoute>> graph = new HashMap<>();
 
@@ -166,8 +165,7 @@ public class HubRouteQueryService {
 
     private List<HubRoute> reconstructPath(Map<UUID, HubRoute> previousRouteMap,
                                            UUID srcHubId,
-                                           UUID destHubId)
-    {
+                                           UUID destHubId) {
         List<HubRoute> path = new ArrayList<>();
         UUID currentHubId = destHubId;
 

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/internal/HubRouteInternalController.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/controller/internal/HubRouteInternalController.java
@@ -1,7 +1,9 @@
 package com.fhsh.daitda.hubservice.hubroute.presentation.controller.internal;
 
+import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRoutePathResult;
 import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.application.service.query.HubRouteQueryService;
+import com.fhsh.daitda.hubservice.hubroute.presentation.dto.response.FindHubRoutePathResponse;
 import com.fhsh.daitda.hubservice.hubroute.presentation.dto.response.FindHubRouteResponse;
 import com.fhsh.daitda.response.CommonResponse;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,11 +37,14 @@ public class HubRouteInternalController {
     }
 
     @GetMapping("/path")
-    public CommonResponse<List<FindHubRouteResponse>> getHubRoutePath(@RequestParam UUID srcHubId, @RequestParam UUID destHubId) {
-        List<FindHubRouteResult> results = hubRouteQueryService.getHubRoutePath(srcHubId, destHubId);
+    public CommonResponse<List<FindHubRoutePathResponse>> getHubRoutePath(
+            @RequestParam UUID srcHubId,
+            @RequestParam UUID destHubId
+    ) {
+        List<FindHubRoutePathResult> results = hubRouteQueryService.getHubRoutePath(srcHubId, destHubId);
 
-        List<FindHubRouteResponse> responses = results.stream()
-                .map(result -> FindHubRouteResponse.from(result))
+        List<FindHubRoutePathResponse> responses = results.stream()
+                .map(FindHubRoutePathResponse::from)
                 .toList();
 
         return CommonResponse.success(responses);

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/dto/response/FindHubRoutePathResponse.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/dto/response/FindHubRoutePathResponse.java
@@ -1,0 +1,38 @@
+package com.fhsh.daitda.hubservice.hubroute.presentation.dto.response;
+
+import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRoutePathResult;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record FindHubRoutePathResponse(
+        Integer sequence,
+        UUID hubRouteId,
+        UUID srcHubId,
+        String srcHubName,
+        String srcHubAddress,
+        UUID destHubId,
+        String destHubName,
+        String destHubAddress,
+        Integer durationTime,
+        String durationMinutes,
+        BigDecimal distance,
+        String distanceKm
+) {
+    public static FindHubRoutePathResponse from(FindHubRoutePathResult result) {
+        return new FindHubRoutePathResponse(
+                result.sequence(),
+                result.hubRouteId(),
+                result.srcHubId(),
+                result.srcHubName(),
+                result.srcHubAddress(),
+                result.destHubId(),
+                result.destHubName(),
+                result.destHubAddress(),
+                result.durationTime(),
+                result.durationMinutes(),
+                result.distance(),
+                result.distanceKm()
+        );
+    }
+}

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/dto/response/FindHubRouteResponse.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/dto/response/FindHubRouteResponse.java
@@ -9,9 +9,15 @@ import java.util.UUID;
 public record FindHubRouteResponse(
         UUID hubRouteId,
         UUID srcHubId,
+        String srcHubName,
+        String srcHubAddress,
         UUID destHubId,
+        String destHubName,
+        String destHubAddress,
         Integer durationTime,
+        String durationMinutes,
         BigDecimal distance,
+        String distanceKm,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -19,9 +25,15 @@ public record FindHubRouteResponse(
         return new FindHubRouteResponse(
                 result.hubRouteId(),
                 result.srcHubId(),
+                result.srcHubName(),
+                result.srcHubAddress(),
                 result.destHubId(),
+                result.destHubName(),
+                result.destHubAddress(),
                 result.durationTime(),
+                result.durationMinutes(),
                 result.distance(),
+                result.distanceKm(),
                 result.createdAt(),
                 result.updatedAt()
         );

--- a/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
@@ -1,6 +1,8 @@
 package com.fhsh.daitda.hubservice.hubroute.application.service.query;
 
 import com.fhsh.daitda.exception.BusinessException;
+import com.fhsh.daitda.hubservice.hub.domain.entity.Hub;
+import com.fhsh.daitda.hubservice.hub.domain.repository.HubRepository;
 import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.domain.entity.HubRoute;
 import com.fhsh.daitda.hubservice.hubroute.domain.exception.HubRouteErrorCode;
@@ -29,6 +31,9 @@ public class HubRouteQueryServiceTest {
     @Mock
     private HubRouteRepository hubRouteRepository;
 
+    @Mock
+    private HubRepository hubRepository;
+
     @InjectMocks
     private HubRouteQueryService hubRouteQueryService;
 
@@ -38,10 +43,52 @@ public class HubRouteQueryServiceTest {
     private static final UUID USER_ID = UUID.randomUUID();
 
     @Test
+    @DisplayName("허브 간 경로 조회 시 허브명, 주소, 표시용 시간/거리를 포함한다")
+    void 허브간경로조회_허브상세포함() {
+        // given
+        HubRoute hubRoute = 생성된경로(SRC_HUB_ID, DEST_HUB_ID, 45, "28.50");
+
+        Hub srcHub = 생성된허브(
+                SRC_HUB_ID,
+                "서울특별시 센터",
+                "서울특별시 송파구 송파대로 55"
+        );
+
+        Hub destHub = 생성된허브(
+                DEST_HUB_ID,
+                "경기 북부 센터",
+                "경기도 고양시 덕양구 권율대로 570"
+        );
+
+        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
+                .thenReturn(Optional.of(hubRoute));
+        when(hubRepository.findByHubIdAndDeletedAtIsNull(SRC_HUB_ID))
+                .thenReturn(Optional.of(srcHub));
+        when(hubRepository.findByHubIdAndDeletedAtIsNull(DEST_HUB_ID))
+                .thenReturn(Optional.of(destHub));
+
+        // when
+        FindHubRouteResult result = hubRouteQueryService.searchHubRoute(SRC_HUB_ID, DEST_HUB_ID);
+
+        // then
+        assertThat(result.srcHubName()).isEqualTo("서울특별시 센터");
+        assertThat(result.srcHubAddress()).isEqualTo("서울특별시 송파구 송파대로 55");
+        assertThat(result.destHubName()).isEqualTo("경기 북부 센터");
+        assertThat(result.destHubAddress()).isEqualTo("경기도 고양시 덕양구 권율대로 570");
+        assertThat(result.durationTime()).isEqualTo(45);
+        assertThat(result.durationMinutes()).isEqualTo("45분");
+        assertThat(result.distance()).isEqualByComparingTo("28.50");
+        assertThat(result.distanceKm()).isEqualTo("28.50km");
+    }
+
+    @Test
     @DisplayName("직행 경로가 200km 미만이면 1개짜리 리스트 반환")
     void 직행경로_200km미만_리스트1건반환() {
         // given
         HubRoute directRoute = 생성된경로(SRC_HUB_ID, DEST_HUB_ID, 120, "150.00");
+
+        stubHub(SRC_HUB_ID, "서울특별시 센터", "서울특별시 송파구 송파대로 55");
+        stubHub(DEST_HUB_ID, "경기 북부 센터", "경기도 고양시 덕양구 권율대로 570");
 
         when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
                 .thenReturn(Optional.of(directRoute));
@@ -53,7 +100,10 @@ public class HubRouteQueryServiceTest {
         assertThat(results).hasSize(1);
         assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
         assertThat(results.get(0).destHubId()).isEqualTo(DEST_HUB_ID);
-        assertThat(results.get(0).distance()).isEqualByComparingTo("150.00");
+        assertThat(results.get(0).srcHubName()).isEqualTo("서울특별시 센터");
+        assertThat(results.get(0).destHubName()).isEqualTo("경기 북부 센터");
+        assertThat(results.get(0).durationMinutes()).isEqualTo("120분");
+        assertThat(results.get(0).distanceKm()).isEqualTo("150.00km");
     }
 
     @Test
@@ -64,9 +114,12 @@ public class HubRouteQueryServiceTest {
         HubRoute firstRelay = 생성된경로(SRC_HUB_ID, VIA_HUB_ID, 120, "160.00");
         HubRoute secondRelay = 생성된경로(VIA_HUB_ID, DEST_HUB_ID, 90, "120.00");
 
+        stubHub(SRC_HUB_ID, "서울특별시 센터", "서울특별시 송파구 송파대로 55");
+        stubHub(VIA_HUB_ID, "대전광역시 센터", "대전 서구 둔산로 100");
+        stubHub(DEST_HUB_ID, "대구광역시 센터", "대구 북구 태평로 161");
+
         when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
                 .thenReturn(Optional.of(directRoute));
-
         when(hubRouteRepository.findAllByDeletedAtIsNull())
                 .thenReturn(List.of(directRoute, firstRelay, secondRelay));
 
@@ -77,8 +130,17 @@ public class HubRouteQueryServiceTest {
         assertThat(results).hasSize(2);
         assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
         assertThat(results.get(0).destHubId()).isEqualTo(VIA_HUB_ID);
+        assertThat(results.get(0).srcHubName()).isEqualTo("서울특별시 센터");
+        assertThat(results.get(0).destHubName()).isEqualTo("대전광역시 센터");
+        assertThat(results.get(0).durationMinutes()).isEqualTo("120분");
+        assertThat(results.get(0).distanceKm()).isEqualTo("160.00km");
+
         assertThat(results.get(1).srcHubId()).isEqualTo(VIA_HUB_ID);
         assertThat(results.get(1).destHubId()).isEqualTo(DEST_HUB_ID);
+        assertThat(results.get(1).srcHubName()).isEqualTo("대전광역시 센터");
+        assertThat(results.get(1).destHubName()).isEqualTo("대구광역시 센터");
+        assertThat(results.get(1).durationMinutes()).isEqualTo("90분");
+        assertThat(results.get(1).distanceKm()).isEqualTo("120.00km");
     }
 
     @Test
@@ -88,9 +150,12 @@ public class HubRouteQueryServiceTest {
         HubRoute firstRelay = 생성된경로(SRC_HUB_ID, VIA_HUB_ID, 120, "120.00");
         HubRoute secondRelay = 생성된경로(VIA_HUB_ID, DEST_HUB_ID, 70, "70.00");
 
+        stubHub(SRC_HUB_ID, "서울특별시 센터", "서울특별시 송파구 송파대로 55");
+        stubHub(VIA_HUB_ID, "대전광역시 센터", "대전 서구 둔산로 100");
+        stubHub(DEST_HUB_ID, "대구광역시 센터", "대구 북구 태평로 161");
+
         when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
                 .thenReturn(Optional.of(directRoute));
-
         when(hubRouteRepository.findAllByDeletedAtIsNull())
                 .thenReturn(List.of(directRoute, firstRelay, secondRelay));
 
@@ -107,23 +172,15 @@ public class HubRouteQueryServiceTest {
     @DisplayName("직행 경로가 없더라도 릴레이 경로가 있으면 리스트를 반환한다")
     void 직행경로없음_릴레이경로반환() {
         // given
-        HubRoute firstRelay = 생성된경로(
-                SRC_HUB_ID,
-                VIA_HUB_ID,
-                120,
-                "160.00"
-        );
+        HubRoute firstRelay = 생성된경로(SRC_HUB_ID, VIA_HUB_ID, 120, "160.00");
+        HubRoute secondRelay = 생성된경로(VIA_HUB_ID, DEST_HUB_ID, 90, "120.00");
 
-        HubRoute secondRelay = 생성된경로(
-                VIA_HUB_ID,
-                DEST_HUB_ID,
-                90,
-                "120.00"
-        );
+        stubHub(SRC_HUB_ID, "서울특별시 센터", "서울특별시 송파구 송파대로 55");
+        stubHub(VIA_HUB_ID, "대전광역시 센터", "대전 서구 둔산로 100");
+        stubHub(DEST_HUB_ID, "대구광역시 센터", "대구 북구 태평로 161");
 
         when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
                 .thenReturn(Optional.empty());
-
         when(hubRouteRepository.findAllByDeletedAtIsNull())
                 .thenReturn(List.of(firstRelay, secondRelay));
 
@@ -141,7 +198,6 @@ public class HubRouteQueryServiceTest {
     @Test
     @DisplayName("출발 허브와 도착 허브가 같으면 예외 발생")
     void 출발도착허브동일_예외() {
-        // when & then
         assertThatThrownBy(() -> hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, SRC_HUB_ID))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("출발 허브와 도착 허브는 같을 수 없습니다.");
@@ -150,18 +206,35 @@ public class HubRouteQueryServiceTest {
     @Test
     @DisplayName("직행도 없고 릴레이 경로도 없으면 예외가 발생")
     void 경로없음_예외() {
-        // given
         when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
                 .thenReturn(Optional.empty());
-
         when(hubRouteRepository.findAllByDeletedAtIsNull())
                 .thenReturn(List.of());
 
-        // when & then
         assertThatThrownBy(() -> hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND);
+    }
+
+    private void stubHub(UUID hubId, String hubName, String hubAddress) {
+        when(hubRepository.findByHubIdAndDeletedAtIsNull(hubId))
+                .thenReturn(Optional.of(생성된허브(hubId, hubName, hubAddress)));
+    }
+
+    private Hub 생성된허브(UUID hubId, String hubName, String hubAddress) {
+        Hub hub = Hub.create(
+                hubName,
+                hubAddress,
+                new BigDecimal("127.100000"),
+                new BigDecimal("37.514000"),
+                false,
+                USER_ID
+        );
+
+        ReflectionTestUtils.invokeMethod(hub, "prePersist");
+        ReflectionTestUtils.setField(hub, "hubId", hubId);
+        return hub;
     }
 
     private HubRoute 생성된경로(UUID srcHubId, UUID destHubId, Integer durationTime, String distance) {

--- a/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
@@ -3,7 +3,7 @@ package com.fhsh.daitda.hubservice.hubroute.application.service.query;
 import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.hubservice.hub.domain.entity.Hub;
 import com.fhsh.daitda.hubservice.hub.domain.repository.HubRepository;
-import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRouteResult;
+import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRoutePathResult;
 import com.fhsh.daitda.hubservice.hubroute.domain.entity.HubRoute;
 import com.fhsh.daitda.hubservice.hubroute.domain.exception.HubRouteErrorCode;
 import com.fhsh.daitda.hubservice.hubroute.domain.repository.HubRouteRepository;
@@ -43,156 +43,81 @@ public class HubRouteQueryServiceTest {
     private static final UUID USER_ID = UUID.randomUUID();
 
     @Test
-    @DisplayName("허브 간 경로 조회 시 허브명, 주소, 표시용 시간/거리를 포함한다")
-    void 허브간경로조회_허브상세포함() {
-        // given
-        HubRoute hubRoute = 생성된경로(SRC_HUB_ID, DEST_HUB_ID, 45, "28.50");
-
-        Hub srcHub = 생성된허브(
-                SRC_HUB_ID,
-                "서울특별시 센터",
-                "서울특별시 송파구 송파대로 55"
-        );
-
-        Hub destHub = 생성된허브(
-                DEST_HUB_ID,
-                "경기 북부 센터",
-                "경기도 고양시 덕양구 권율대로 570"
-        );
-
-        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
-                .thenReturn(Optional.of(hubRoute));
-        when(hubRepository.findByHubIdAndDeletedAtIsNull(SRC_HUB_ID))
-                .thenReturn(Optional.of(srcHub));
-        when(hubRepository.findByHubIdAndDeletedAtIsNull(DEST_HUB_ID))
-                .thenReturn(Optional.of(destHub));
-
-        // when
-        FindHubRouteResult result = hubRouteQueryService.searchHubRoute(SRC_HUB_ID, DEST_HUB_ID);
-
-        // then
-        assertThat(result.srcHubName()).isEqualTo("서울특별시 센터");
-        assertThat(result.srcHubAddress()).isEqualTo("서울특별시 송파구 송파대로 55");
-        assertThat(result.destHubName()).isEqualTo("경기 북부 센터");
-        assertThat(result.destHubAddress()).isEqualTo("경기도 고양시 덕양구 권율대로 570");
-        assertThat(result.durationTime()).isEqualTo(45);
-        assertThat(result.durationMinutes()).isEqualTo("45분");
-        assertThat(result.distance()).isEqualByComparingTo("28.50");
-        assertThat(result.distanceKm()).isEqualTo("28.50km");
-    }
-
-    @Test
-    @DisplayName("직행 경로가 200km 미만이면 1개짜리 리스트 반환")
+    @DisplayName("직행 경로가 200km 미만이면 sequence 1인 1개 리스트 반환")
     void 직행경로_200km미만_리스트1건반환() {
-        // given
         HubRoute directRoute = 생성된경로(SRC_HUB_ID, DEST_HUB_ID, 120, "150.00");
 
-        stubHub(SRC_HUB_ID, "서울특별시 센터", "서울특별시 송파구 송파대로 55");
-        stubHub(DEST_HUB_ID, "경기 북부 센터", "경기도 고양시 덕양구 권율대로 570");
+        stubHub(SRC_HUB_ID, "서울 허브", "서울특별시 송파구 충민로 10");
+        stubHub(DEST_HUB_ID, "대전 허브", "대전광역시 유성구 테크노중앙로 123");
 
         when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
                 .thenReturn(Optional.of(directRoute));
 
-        // when
-        List<FindHubRouteResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
+        List<FindHubRoutePathResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
 
-        // then
         assertThat(results).hasSize(1);
+        assertThat(results.get(0).sequence()).isEqualTo(1);
         assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
         assertThat(results.get(0).destHubId()).isEqualTo(DEST_HUB_ID);
-        assertThat(results.get(0).srcHubName()).isEqualTo("서울특별시 센터");
-        assertThat(results.get(0).destHubName()).isEqualTo("경기 북부 센터");
+        assertThat(results.get(0).srcHubName()).isEqualTo("서울 허브");
+        assertThat(results.get(0).destHubName()).isEqualTo("대전 허브");
         assertThat(results.get(0).durationMinutes()).isEqualTo("120분");
         assertThat(results.get(0).distanceKm()).isEqualTo("150.00km");
     }
 
     @Test
-    @DisplayName("직행 경로가 200km 이상이면 릴레이 경로 리스트를 반환한다")
+    @DisplayName("직행 경로가 200km 이상이면 sequence가 붙은 릴레이 경로 리스트를 반환한다")
     void 직행경로_200km이상_릴레이경로반환() {
-        // given
         HubRoute directRoute = 생성된경로(SRC_HUB_ID, DEST_HUB_ID, 240, "280.00");
         HubRoute firstRelay = 생성된경로(SRC_HUB_ID, VIA_HUB_ID, 120, "160.00");
         HubRoute secondRelay = 생성된경로(VIA_HUB_ID, DEST_HUB_ID, 90, "120.00");
 
-        stubHub(SRC_HUB_ID, "서울특별시 센터", "서울특별시 송파구 송파대로 55");
-        stubHub(VIA_HUB_ID, "대전광역시 센터", "대전 서구 둔산로 100");
-        stubHub(DEST_HUB_ID, "대구광역시 센터", "대구 북구 태평로 161");
+        stubHub(SRC_HUB_ID, "서울 허브", "서울특별시 송파구 충민로 10");
+        stubHub(VIA_HUB_ID, "대전 허브", "대전광역시 유성구 테크노중앙로 123");
+        stubHub(DEST_HUB_ID, "대구 허브", "대구광역시 동구 동대구로 456");
 
         when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
                 .thenReturn(Optional.of(directRoute));
         when(hubRouteRepository.findAllByDeletedAtIsNull())
                 .thenReturn(List.of(directRoute, firstRelay, secondRelay));
 
-        // when
-        List<FindHubRouteResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
+        List<FindHubRoutePathResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
 
-        // then
         assertThat(results).hasSize(2);
+
+        assertThat(results.get(0).sequence()).isEqualTo(1);
         assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
         assertThat(results.get(0).destHubId()).isEqualTo(VIA_HUB_ID);
-        assertThat(results.get(0).srcHubName()).isEqualTo("서울특별시 센터");
-        assertThat(results.get(0).destHubName()).isEqualTo("대전광역시 센터");
-        assertThat(results.get(0).durationMinutes()).isEqualTo("120분");
-        assertThat(results.get(0).distanceKm()).isEqualTo("160.00km");
+        assertThat(results.get(0).srcHubName()).isEqualTo("서울 허브");
+        assertThat(results.get(0).destHubName()).isEqualTo("대전 허브");
 
+        assertThat(results.get(1).sequence()).isEqualTo(2);
         assertThat(results.get(1).srcHubId()).isEqualTo(VIA_HUB_ID);
         assertThat(results.get(1).destHubId()).isEqualTo(DEST_HUB_ID);
-        assertThat(results.get(1).srcHubName()).isEqualTo("대전광역시 센터");
-        assertThat(results.get(1).destHubName()).isEqualTo("대구광역시 센터");
-        assertThat(results.get(1).durationMinutes()).isEqualTo("90분");
-        assertThat(results.get(1).distanceKm()).isEqualTo("120.00km");
+        assertThat(results.get(1).srcHubName()).isEqualTo("대전 허브");
+        assertThat(results.get(1).destHubName()).isEqualTo("대구 허브");
     }
 
     @Test
-    @DisplayName("직행 경로가 200km이면 릴레이 경로 리스트를 반환한다")
-    void 직행경로_200km_릴레이경로반환() {
-        HubRoute directRoute = 생성된경로(SRC_HUB_ID, DEST_HUB_ID, 180, "200.00");
-        HubRoute firstRelay = 생성된경로(SRC_HUB_ID, VIA_HUB_ID, 120, "120.00");
-        HubRoute secondRelay = 생성된경로(VIA_HUB_ID, DEST_HUB_ID, 70, "70.00");
-
-        stubHub(SRC_HUB_ID, "서울특별시 센터", "서울특별시 송파구 송파대로 55");
-        stubHub(VIA_HUB_ID, "대전광역시 센터", "대전 서구 둔산로 100");
-        stubHub(DEST_HUB_ID, "대구광역시 센터", "대구 북구 태평로 161");
-
-        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
-                .thenReturn(Optional.of(directRoute));
-        when(hubRouteRepository.findAllByDeletedAtIsNull())
-                .thenReturn(List.of(directRoute, firstRelay, secondRelay));
-
-        List<FindHubRouteResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
-
-        assertThat(results).hasSize(2);
-        assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
-        assertThat(results.get(0).destHubId()).isEqualTo(VIA_HUB_ID);
-        assertThat(results.get(1).srcHubId()).isEqualTo(VIA_HUB_ID);
-        assertThat(results.get(1).destHubId()).isEqualTo(DEST_HUB_ID);
-    }
-
-    @Test
-    @DisplayName("직행 경로가 없더라도 릴레이 경로가 있으면 리스트를 반환한다")
+    @DisplayName("직행 경로가 없더라도 릴레이 경로가 있으면 sequence가 붙은 리스트를 반환한다")
     void 직행경로없음_릴레이경로반환() {
-        // given
         HubRoute firstRelay = 생성된경로(SRC_HUB_ID, VIA_HUB_ID, 120, "160.00");
         HubRoute secondRelay = 생성된경로(VIA_HUB_ID, DEST_HUB_ID, 90, "120.00");
 
-        stubHub(SRC_HUB_ID, "서울특별시 센터", "서울특별시 송파구 송파대로 55");
-        stubHub(VIA_HUB_ID, "대전광역시 센터", "대전 서구 둔산로 100");
-        stubHub(DEST_HUB_ID, "대구광역시 센터", "대구 북구 태평로 161");
+        stubHub(SRC_HUB_ID, "서울 허브", "서울특별시 송파구 충민로 10");
+        stubHub(VIA_HUB_ID, "대전 허브", "대전광역시 유성구 테크노중앙로 123");
+        stubHub(DEST_HUB_ID, "대구 허브", "대구광역시 동구 동대구로 456");
 
         when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
                 .thenReturn(Optional.empty());
         when(hubRouteRepository.findAllByDeletedAtIsNull())
                 .thenReturn(List.of(firstRelay, secondRelay));
 
-        // when
-        List<FindHubRouteResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
+        List<FindHubRoutePathResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
 
-        // then
         assertThat(results).hasSize(2);
-        assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
-        assertThat(results.get(0).destHubId()).isEqualTo(VIA_HUB_ID);
-        assertThat(results.get(1).srcHubId()).isEqualTo(VIA_HUB_ID);
-        assertThat(results.get(1).destHubId()).isEqualTo(DEST_HUB_ID);
+        assertThat(results.get(0).sequence()).isEqualTo(1);
+        assertThat(results.get(1).sequence()).isEqualTo(2);
     }
 
     @Test
@@ -248,7 +173,6 @@ public class HubRouteQueryServiceTest {
 
         ReflectionTestUtils.invokeMethod(hubRoute, "prePersist");
         ReflectionTestUtils.setField(hubRoute, "createdAt", LocalDateTime.now());
-
         return hubRoute;
     }
 }


### PR DESCRIPTION
## 🌱 설명

허브 경로 관련 응답을 확장하고, 내부 최종 배송 경로 조회 API 응답을 분리

- 허브 간 경로 조회/생성 응답에 허브명, 허브 주소, 표시용 거리/시간 필드를 추가
- 내부 최종 배송 경로 조회 API(`/internal/v1/hub-routes/path`) 응답을 path 전용 DTO로 분리하고 `sequence`를 추가
- 200km 기준 정책에 따라 직행은 1건 리스트, 장거리 경로는 릴레이 경로 리스트로 반환하도록 정리


## 📌 관련 이슈

- close #29 

## ✅ 주요 변경 사항

- 허브 경로 생성/수정 응답에도 허브명, 허브 주소가 포함되도록 수정
- 내부 허브 간 경로 조회 API 응답 확장
- 내부 최종 배송 경로 조회 API 응답을 path 전용 DTO/Response로 분리
- 최종 배송 경로 조회 응답에 `sequence` 필드 추가
- 200km 미만 / 이상 케이스에 대한 내부 path 조회 로직 반영
- 관련 테스트 코드 추가 및 수정

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- `durationTime`은 분 단위, `distance`는 km 단위
- 표시용 문자열 필드로 `durationMinutes`, `distanceKm`를 추가
- `/internal/v1/hub-routes/path`는 저장된 `hub_route` 그래프를 기준으로 릴레이 경로를 탐색하므로, 장거리 경로 검증 시 중간 구간 데이터가 사전에 등록되어 있어야 합니다
- 수동 검증 완료
  - `POST /api/v1/hub-routes`
  - `GET /internal/v1/hub-routes`
  - `GET /internal/v1/hub-routes/path`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

- 허브 경로 조회 결과에 출발지 및 도착지 허브명과 주소 정보가 추가되었습니다.
- 경로 경로 조회 응답에서 각 구간별 순서 번호가 포함되어 반환됩니다.
- 이동 시간은 한국식 '분' 단위로, 거리는 'km' 단위로 포맷되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->