### PR TITLE
[refactor] improve final delivery route lookup by adopting a policy based waypoint splitting approach

### DIFF
--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRoutePathResult.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRoutePathResult.java
@@ -44,13 +44,21 @@ public record FindHubRoutePathResult(
         );
     }
 
+    /**
+     * 분 단위 소요시간을 사람이 읽기 쉬운 문자열로 변환
+     * - 60분 이하: "N분"
+     * - 60분 초과: "N시간 M분"
+     * - 정각 시간: "N시간"
+     */
     private static String toDurationText(Integer durationTime) {
+        // 소요시간이 60분 이하 일시 "분" 표시 추가
+        if (durationTime <= 60) {
+            return durationTime + "분";
+        }
+
         int hours = durationTime / 60;
         int minutes = durationTime % 60;
 
-        if (hours == 0) {
-            return minutes + "분";
-        }
         if (minutes == 0) {
             return hours + "시간";
         }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRoutePathResult.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRoutePathResult.java
@@ -1,7 +1,6 @@
 package com.fhsh.daitda.hubservice.hubroute.application.result;
 
 import com.fhsh.daitda.hubservice.hub.domain.entity.Hub;
-import com.fhsh.daitda.hubservice.hubroute.domain.entity.HubRoute;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -17,32 +16,48 @@ public record FindHubRoutePathResult(
         String destHubName,
         String destHubAddress,
         Integer durationTime,
-        String durationMinutes,
+        String durationText,
         BigDecimal distance,
-        String distanceKm
+        String distanceText
 ) {
-    public static FindHubRoutePathResult from(Integer sequence, HubRoute hubRoute, Hub srcHub, Hub destHub) {
+    public static FindHubRoutePathResult of(
+            Integer sequence,
+            UUID hubRouteId,
+            Hub srcHub,
+            Hub destHub,
+            Integer durationTime,
+            BigDecimal distance
+    ) {
         return new FindHubRoutePathResult(
                 sequence,
-                hubRoute.getHubRouteId(),
-                hubRoute.getSrcHubId(),
+                hubRouteId,
+                srcHub.getHubId(),
                 srcHub.getHubName(),
                 srcHub.getHubAddress(),
-                hubRoute.getDestHubId(),
+                destHub.getHubId(),
                 destHub.getHubName(),
                 destHub.getHubAddress(),
-                hubRoute.getDurationTime(),
-                toDurationMinutes(hubRoute.getDurationTime()),
-                hubRoute.getDistance(),
-                toDistanceKm(hubRoute.getDistance())
+                durationTime,
+                toDurationText(durationTime),
+                distance,
+                toDistanceText(distance)
         );
     }
 
-    private static String toDurationMinutes(Integer durationTime) {
-        return durationTime + "분";
+    private static String toDurationText(Integer durationTime) {
+        int hours = durationTime / 60;
+        int minutes = durationTime % 60;
+
+        if (hours == 0) {
+            return minutes + "분";
+        }
+        if (minutes == 0) {
+            return hours + "시간";
+        }
+        return hours + "시간 " + minutes + "분";
     }
 
-    private static String toDistanceKm(BigDecimal distance) {
+    private static String toDistanceText(BigDecimal distance) {
         return distance.setScale(2, RoundingMode.HALF_UP).toPlainString() + "km";
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRouteResult.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRouteResult.java
@@ -41,13 +41,21 @@ public record FindHubRouteResult(
         );
     }
 
+    /**
+     * 분 단위 소요시간을 사람이 읽기 쉬운 문자열로 변환
+     * - 60분 이하: "N분"
+     * - 60분 초과: "N시간 M분"
+     * - 정각 시간: "N시간"
+     */
     private static String toDurationText(Integer durationTime) {
+        // 소요시간이 60분 이하 일시 "분" 표시 추가
+        if (durationTime <= 60) {
+            return durationTime + "분";
+        }
+
         int hours = durationTime / 60;
         int minutes = durationTime % 60;
 
-        if (hours == 0) {
-            return minutes + "분";
-        }
         if (minutes == 0) {
             return hours + "시간";
         }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRouteResult.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/result/FindHubRouteResult.java
@@ -17,13 +17,12 @@ public record FindHubRouteResult(
         String destHubName,
         String destHubAddress,
         Integer durationTime,
-        String durationMinutes,
+        String durationText,
         BigDecimal distance,
-        String distanceKm,
+        String distanceText,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-
     public static FindHubRouteResult from(HubRoute hubRoute, Hub srcHub, Hub destHub) {
         return new FindHubRouteResult(
                 hubRoute.getHubRouteId(),
@@ -34,19 +33,28 @@ public record FindHubRouteResult(
                 destHub.getHubName(),
                 destHub.getHubAddress(),
                 hubRoute.getDurationTime(),
-                toDurationMinutes(hubRoute.getDurationTime()),
+                toDurationText(hubRoute.getDurationTime()),
                 hubRoute.getDistance(),
-                toDistanceKm(hubRoute.getDistance()),
+                toDistanceText(hubRoute.getDistance()),
                 hubRoute.getCreatedAt(),
                 hubRoute.getUpdatedAt()
         );
     }
 
-    private static String toDurationMinutes(Integer durationTime) {
-        return durationTime + "분";
+    private static String toDurationText(Integer durationTime) {
+        int hours = durationTime / 60;
+        int minutes = durationTime % 60;
+
+        if (hours == 0) {
+            return minutes + "분";
+        }
+        if (minutes == 0) {
+            return hours + "시간";
+        }
+        return hours + "시간 " + minutes + "분";
     }
 
-    private static String toDistanceKm(BigDecimal distance) {
+    private static String toDistanceText(BigDecimal distance) {
         return distance.setScale(2, RoundingMode.HALF_UP).toPlainString() + "km";
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class HubRouteQueryService {
 
-    private static final BigDecimal RELAY_THRESHOLD_KM = new BigDecimal("200");
+    private static final long RELAY_THRESHOLD_METERS = 200_000L;
 
     private final HubRouteRepository hubRouteRepository;
     private final HubRepository hubRepository;
@@ -83,7 +83,7 @@ public class HubRouteQueryService {
         );
 
         // 200km 미만이면 직행 1건 반환
-        if (directMetrics.distanceKilometers().compareTo(RELAY_THRESHOLD_KM) < 0) {
+        if (directMetrics.distanceMeters() < RELAY_THRESHOLD_METERS) {
             return List.of(
                     toPathResult(
                             1,
@@ -153,7 +153,7 @@ public class HubRouteQueryService {
         // 가장 적절하다고 판단된 경유 허브
         Hub bestRelayHub = null;
         // 가장 짧은 총거리 (출발 - 경유 + 경유 - 도착)
-        BigDecimal bestTotalDistance = null;
+        Long bestTotalDistanceMeters = null;
 
         for (Hub candidate : hubs) {
             // 출발, 도착 허브는 경유가 될 수 없음
@@ -182,19 +182,19 @@ public class HubRouteQueryService {
             );
 
             // 두 구간 모두 200km 미만이어야 유효한 후보
-            if (firstMetrics.distanceKilometers().compareTo(RELAY_THRESHOLD_KM) >= 0) {
+            if (firstMetrics.distanceMeters() >= RELAY_THRESHOLD_METERS) {
                 continue;
             }
-            if (secondMetrics.distanceKilometers().compareTo(RELAY_THRESHOLD_KM) >= 0) {
+            if (secondMetrics.distanceMeters() >= RELAY_THRESHOLD_METERS) {
                 continue;
             }
 
             // 후보 허브를 경유했을 떄의 총 거리
-            BigDecimal totalDistance = firstMetrics.distanceKilometers().add(secondMetrics.distanceKilometers());
+            long totalDistanceMeters = firstMetrics.distanceMeters() + secondMetrics.distanceMeters();
 
             // 아직 선택된 후보가 없거나 더 좋은 후보가 있을시 갱신
-            if (bestTotalDistance == null || totalDistance.compareTo(bestTotalDistance) < 0) {
-                bestTotalDistance = totalDistance;
+            if (bestTotalDistanceMeters == null || totalDistanceMeters < bestTotalDistanceMeters) {
+                bestTotalDistanceMeters = totalDistanceMeters;
                 bestRelayHub = candidate;
             }
         }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryService.java
@@ -10,31 +10,34 @@ import com.fhsh.daitda.hubservice.hubroute.application.result.ListHubRouteResult
 import com.fhsh.daitda.hubservice.hubroute.domain.entity.HubRoute;
 import com.fhsh.daitda.hubservice.hubroute.domain.exception.HubRouteErrorCode;
 import com.fhsh.daitda.hubservice.hubroute.domain.repository.HubRouteRepository;
+import com.fhsh.daitda.hubservice.infrastructure.kakao.client.KakaoDirectionsClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @Transactional(readOnly = true)
 public class HubRouteQueryService {
 
-    /**
-     * 릴레이 배송으로 전환할 기준 거리
-     */
     private static final BigDecimal RELAY_THRESHOLD_KM = new BigDecimal("200");
 
     private final HubRouteRepository hubRouteRepository;
     private final HubRepository hubRepository;
+    private final KakaoDirectionsClient kakaoDirectionsClient;
 
     public HubRouteQueryService(HubRouteRepository hubRouteRepository,
-                                HubRepository hubRepository) {
+                                HubRepository hubRepository,
+                                KakaoDirectionsClient kakaoDirectionsClient) {
         this.hubRouteRepository = hubRouteRepository;
         this.hubRepository = hubRepository;
+        this.kakaoDirectionsClient = kakaoDirectionsClient;
     }
 
-    // 삭제되지 않은 전체 허브 경로 목록 조회
     public List<ListHubRouteResult> getHubRoutes() {
         return hubRouteRepository.findAllByDeletedAtIsNull()
                 .stream()
@@ -42,13 +45,11 @@ public class HubRouteQueryService {
                 .toList();
     }
 
-    // 허브 경로 ID 기준으로 단건 경로 조회
     public FindHubRouteResult getHubRoute(UUID hubRouteId) {
         HubRoute hubRoute = findActiveHubRoute(hubRouteId);
         return toFindHubRouteResult(hubRoute);
     }
 
-    // 출발 허브와 도착 허브 조합으로 개별 구간 route를 조회
     public FindHubRouteResult searchHubRoute(UUID srcHubId, UUID destHubId) {
         HubRoute hubRoute = hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(srcHubId, destHubId)
                 .orElseThrow(() -> new BusinessException(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND));
@@ -57,28 +58,197 @@ public class HubRouteQueryService {
     }
 
     /**
-     * 최종 배송 경로(path)를 조회
+     * 최종 배송 경로(path) 조회
      *
      * 정책:
-     * - 직행 route가 존재하고 거리가 200km 미만이면 1개짜리 리스트 반환
-     * - 직행 route가 200km 이상이거나 직행 route가 없으면 릴레이 경로를 계산해서 리스트 반환
+     * - 출발 허브와 도착 허브의 직행 거리를 먼저 계산
+     * - 직행 거리가 200km 미만이면 직행 1건만 반환
+     * - 직행 거리가 200km 이상이면 relay hub를 1개 선정해 2구간으로 분할 반환
+     *
+     * 반환값:
+     * - 200km 미만: sequence=1 인 1건 리스트
+     * - 200km 이상: sequence=1,2 인 2건 리스트
      */
     public List<FindHubRoutePathResult> getHubRoutePath(UUID srcHubId, UUID destHubId) {
         validateDifferentHub(srcHubId, destHubId);
 
-        Optional<HubRoute> directRoute = hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(srcHubId, destHubId);
+        Hub srcHub = findActiveHub(srcHubId);
+        Hub destHub = findActiveHub(destHubId);
 
-        if (directRoute.isPresent() && directRoute.get().getDistance().compareTo(RELAY_THRESHOLD_KM) < 0) {
-            return List.of(toFindHubRoutePathResult(1, directRoute.get()));
+        KakaoDirectionsClient.RouteMetrics directMetrics = kakaoDirectionsClient.getDrivingMetrics(
+                srcHub.getLongitude(),
+                srcHub.getLatitude(),
+                destHub.getLongitude(),
+                destHub.getLatitude()
+        );
+
+        // 200km 미만이면 직행 1건 반환
+        if (directMetrics.distanceKilometers().compareTo(RELAY_THRESHOLD_KM) < 0) {
+            return List.of(
+                    toPathResult(
+                            1,
+                            findHubRouteIdOrNull(srcHubId, destHubId),
+                            srcHub,
+                            destHub,
+                            directMetrics.durationMinutes(),
+                            directMetrics.distanceKilometers()
+                    )
+            );
         }
 
-        List<HubRoute> relayPath = findRelayPath(srcHubId, destHubId);
+        // 200km 이상이면 relay hub 선정
+        Hub relayHub = selectRelayHub(srcHub, destHub);
+
+        KakaoDirectionsClient.RouteMetrics firstMetrics = kakaoDirectionsClient.getDrivingMetrics(
+                srcHub.getLongitude(),
+                srcHub.getLatitude(),
+                relayHub.getLongitude(),
+                relayHub.getLatitude()
+        );
+
+        KakaoDirectionsClient.RouteMetrics secondMetrics = kakaoDirectionsClient.getDrivingMetrics(
+                relayHub.getLongitude(),
+                relayHub.getLatitude(),
+                destHub.getLongitude(),
+                destHub.getLatitude()
+        );
 
         List<FindHubRoutePathResult> results = new ArrayList<>();
-        for (int i = 0; i < relayPath.size(); i++) {
-            results.add(toFindHubRoutePathResult(i + 1, relayPath.get(i)));
-        }
+        results.add(
+                toPathResult(
+                        1,
+                        findHubRouteIdOrNull(srcHub.getHubId(), relayHub.getHubId()),
+                        srcHub,
+                        relayHub,
+                        firstMetrics.durationMinutes(),
+                        firstMetrics.distanceKilometers()
+                )
+        );
+        results.add(
+                toPathResult(
+                        2,
+                        findHubRouteIdOrNull(relayHub.getHubId(), destHub.getHubId()),
+                        relayHub,
+                        destHub,
+                        secondMetrics.durationMinutes(),
+                        secondMetrics.distanceKilometers()
+                )
+        );
+
         return results;
+    }
+
+    /**
+     * 200km 이상 장거리 배송 시 사용할 중간 경유 허브를 선정
+     *
+     * 선정 기준:
+     * - 활성 허브 중 출발/도착 허브를 제외한 후보를 순회
+     * - 각 후보에 대해 [출발 -> 후보], [후보 -> 도착] 거리를 카카오로 계산
+     * - 두 구간 모두 200km 미만인 후보만 유효하다.
+     * - 유효 후보 중 총 거리 합이 가장 짧은 허브를 relay hub로 선택
+     */
+    private Hub selectRelayHub(Hub srcHub, Hub destHub) {
+        List<Hub> hubs = hubRepository.findAllByDeletedAtIsNull();
+
+        // 가장 적절하다고 판단된 경유 허브
+        Hub bestRelayHub = null;
+        // 가장 짧은 총거리 (출발 - 경유 + 경유 - 도착)
+        BigDecimal bestTotalDistance = null;
+
+        for (Hub candidate : hubs) {
+            // 출발, 도착 허브는 경유가 될 수 없음
+            if (candidate.getHubId().equals(srcHub.getHubId()) || candidate.getHubId().equals(destHub.getHubId())) {
+                continue;
+            }
+
+            /**
+             * 출발 - 경유후보? 구간의 길찾기 결과 계산
+             * 허브 경유 구간이 가능한지 판단
+             */
+            KakaoDirectionsClient.RouteMetrics firstMetrics = kakaoDirectionsClient.getDrivingMetrics(
+                    srcHub.getLongitude(),
+                    srcHub.getLatitude(),
+                    candidate.getLongitude(),
+                    candidate.getLatitude()
+            );
+
+
+            // 경유 - 도착 구간의 길찾기 결과 계산
+            KakaoDirectionsClient.RouteMetrics secondMetrics = kakaoDirectionsClient.getDrivingMetrics(
+                    candidate.getLongitude(),
+                    candidate.getLatitude(),
+                    destHub.getLongitude(),
+                    destHub.getLatitude()
+            );
+
+            // 두 구간 모두 200km 미만이어야 유효한 후보
+            if (firstMetrics.distanceKilometers().compareTo(RELAY_THRESHOLD_KM) >= 0) {
+                continue;
+            }
+            if (secondMetrics.distanceKilometers().compareTo(RELAY_THRESHOLD_KM) >= 0) {
+                continue;
+            }
+
+            // 후보 허브를 경유했을 떄의 총 거리
+            BigDecimal totalDistance = firstMetrics.distanceKilometers().add(secondMetrics.distanceKilometers());
+
+            // 아직 선택된 후보가 없거나 더 좋은 후보가 있을시 갱신
+            if (bestTotalDistance == null || totalDistance.compareTo(bestTotalDistance) < 0) {
+                bestTotalDistance = totalDistance;
+                bestRelayHub = candidate;
+            }
+        }
+
+        // 끝까지 돌려도 없을시 예외
+        if (bestRelayHub == null) {
+            throw new BusinessException(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND);
+        }
+
+        return bestRelayHub;
+    }
+
+    /**
+     * 계산된 구간과 동일한 저장된 hub_route가 있으면 해당 ID를 반환
+     * 등록된 경로가 없으면 null을 반환
+     *
+     * path 조회는 저장된 경로 조회만을 의미하지 않음
+     * 정책 기반으로 계산된 배송 구간도 응답에 포함할 수 있다
+     * - 이미 등록된 구간이면 hubRouteId를 응답에 포함
+     * - 아직 등록되지 않은 계산 구간이면 hubRouteId는 null반환
+     *
+     * hubRouteId가 null인 것은 오류가 아니라
+     * (계산은 되었지만 DB에 저장된 허브 경로 row는 없음)-허브 간 이동정보 등록이 안됨 을 의미합니다
+     */
+    private UUID findHubRouteIdOrNull(UUID srcHubId, UUID destHubId) {
+
+        // 출발 허브ID와 도착 허브ID가 정확히 일치하는 저장된 허브 조회
+        Optional<HubRoute> hubRoute = hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(srcHubId, destHubId);
+
+        //만약 저장된 경로가 있으면 HubRouteId를 반환 그렇지 않으면 null 반환
+        return hubRoute.map(route -> route.getHubRouteId())
+                .orElse(null);
+    }
+
+    /**
+     * 최종 배송 경로 조회 응답용 DTO를 생성
+     *
+     * 숫자 원본(distance, durationTime)과 함께
+     * 표시용 문자열(distanceText, durationText)도 함께 내림
+     */
+    private FindHubRoutePathResult toPathResult(Integer sequence,
+                                                UUID hubRouteId,
+                                                Hub srcHub,
+                                                Hub destHub,
+                                                Integer durationTime,
+                                                BigDecimal distance) {
+        return FindHubRoutePathResult.of(
+                sequence,
+                hubRouteId,
+                srcHub,
+                destHub,
+                durationTime,
+                distance
+        );
     }
 
     private FindHubRouteResult toFindHubRouteResult(HubRoute hubRoute) {
@@ -87,112 +257,9 @@ public class HubRouteQueryService {
         return FindHubRouteResult.from(hubRoute, srcHub, destHub);
     }
 
-    private FindHubRoutePathResult toFindHubRoutePathResult(Integer sequence, HubRoute hubRoute) {
-        Hub srcHub = findActiveHub(hubRoute.getSrcHubId());
-        Hub destHub = findActiveHub(hubRoute.getDestHubId());
-        return FindHubRoutePathResult.from(sequence, hubRoute, srcHub, destHub);
-    }
-
     private Hub findActiveHub(UUID hubId) {
         return hubRepository.findByHubIdAndDeletedAtIsNull(hubId)
                 .orElseThrow(() -> new BusinessException(HubErrorCode.HUB_NOT_FOUND));
-    }
-
-    /**
-     * 릴레이 경로를 계산
-     *
-     * active route를 그래프로 보는 이유
-     * - hub_route row는 개별 구간 edge 역할을 하기 때문
-     * - 최종 배송 경로(path)는 여러 edge를 이어 붙인 결과이기 때문
-     *
-     * 다익스트라를 쓰는 이유:
-     * - distance가 가중치인 최단 경로 문제로 볼 수 있기 때문
-     * - 현재 요구사항에서는 가장 자연스럽고 구현도 안정적인 방식이기 때문
-     */
-    private List<HubRoute> findRelayPath(UUID srcHubId, UUID destHubId) {
-        List<HubRoute> routes = hubRouteRepository.findAllByDeletedAtIsNull();
-
-        List<HubRoute> relayCandidates = routes.stream()
-                .filter(route -> !(route.getSrcHubId().equals(srcHubId) && route.getDestHubId().equals(destHubId)))
-                .toList();
-
-        Map<UUID, List<HubRoute>> graph = buildGraph(relayCandidates);
-        Map<UUID, BigDecimal> distanceMap = new HashMap<>();
-        Map<UUID, HubRoute> previousRouteMap = new HashMap<>();
-
-        PriorityQueue<RouteNode> pq = new PriorityQueue<>((o1, o2) ->
-                o1.distance().compareTo(o2.distance())
-        );
-
-        distanceMap.put(srcHubId, BigDecimal.ZERO);
-        pq.offer(new RouteNode(srcHubId, BigDecimal.ZERO));
-
-        while (!pq.isEmpty()) {
-            RouteNode current = pq.poll();
-
-            BigDecimal knownDistance = distanceMap.getOrDefault(
-                    current.hubId(),
-                    BigDecimal.valueOf(Double.MAX_VALUE)
-            );
-
-            if (current.distance().compareTo(knownDistance) > 0) {
-                continue;
-            }
-
-            if (current.hubId().equals(destHubId)) {
-                break;
-            }
-
-            List<HubRoute> nextRoutes = graph.getOrDefault(current.hubId(), Collections.emptyList());
-
-            for (HubRoute nextRoute : nextRoutes) {
-                UUID nextHubId = nextRoute.getDestHubId();
-                BigDecimal nextDistance = current.distance().add(nextRoute.getDistance());
-
-                BigDecimal recordedDistance = distanceMap.get(nextHubId);
-
-                if (recordedDistance == null || nextDistance.compareTo(recordedDistance) < 0) {
-                    distanceMap.put(nextHubId, nextDistance);
-                    previousRouteMap.put(nextHubId, nextRoute);
-                    pq.offer(new RouteNode(nextHubId, nextDistance));
-                }
-            }
-        }
-
-        if (!previousRouteMap.containsKey(destHubId)) {
-            throw new BusinessException(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND);
-        }
-        return reconstructPath(previousRouteMap, srcHubId, destHubId);
-    }
-
-    private Map<UUID, List<HubRoute>> buildGraph(List<HubRoute> routes) {
-        Map<UUID, List<HubRoute>> graph = new HashMap<>();
-
-        for (HubRoute route : routes) {
-            graph.computeIfAbsent(route.getSrcHubId(), key -> new ArrayList<>()).add(route);
-        }
-        return graph;
-    }
-
-    private List<HubRoute> reconstructPath(Map<UUID, HubRoute> previousRouteMap,
-                                           UUID srcHubId,
-                                           UUID destHubId) {
-        List<HubRoute> path = new ArrayList<>();
-        UUID currentHubId = destHubId;
-
-        while (!currentHubId.equals(srcHubId)) {
-            HubRoute route = previousRouteMap.get(currentHubId);
-
-            if (route == null) {
-                throw new BusinessException(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND);
-            }
-
-            path.add(route);
-            currentHubId = route.getSrcHubId();
-        }
-
-        Collections.reverse(path);
-        return path;
     }
 
     private void validateDifferentHub(UUID srcHubId, UUID destHubId) {
@@ -208,20 +275,5 @@ public class HubRouteQueryService {
     private HubRoute findActiveHubRoute(UUID hubRouteId) {
         return hubRouteRepository.findByHubRouteIdAndDeletedAtIsNull(hubRouteId)
                 .orElseThrow(() -> new BusinessException(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND));
-    }
-
-    /**
-     * 우선순위 큐에 넣을 노드
-     *
-     * hubId:
-     * - 현재 도착해 있는 허브
-     *
-     * distance:
-     * - 출발 허브부터 현재 허브까지 누적 거리
-     *
-     * 필요한 이유:
-     * - 다익스트라에서 "가장 짧은 후보부터 먼저 처리"해야 하기 때문
-     */
-    private record RouteNode(UUID hubId, BigDecimal distance) {
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/dto/response/FindHubRoutePathResponse.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/dto/response/FindHubRoutePathResponse.java
@@ -15,9 +15,9 @@ public record FindHubRoutePathResponse(
         String destHubName,
         String destHubAddress,
         Integer durationTime,
-        String durationMinutes,
+        String durationText,
         BigDecimal distance,
-        String distanceKm
+        String distanceText
 ) {
     public static FindHubRoutePathResponse from(FindHubRoutePathResult result) {
         return new FindHubRoutePathResponse(
@@ -30,9 +30,9 @@ public record FindHubRoutePathResponse(
                 result.destHubName(),
                 result.destHubAddress(),
                 result.durationTime(),
-                result.durationMinutes(),
+                result.durationText(),
                 result.distance(),
-                result.distanceKm()
+                result.distanceText()
         );
     }
 }

--- a/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/dto/response/FindHubRouteResponse.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/hubroute/presentation/dto/response/FindHubRouteResponse.java
@@ -15,9 +15,9 @@ public record FindHubRouteResponse(
         String destHubName,
         String destHubAddress,
         Integer durationTime,
-        String durationMinutes,
+        String durationText,
         BigDecimal distance,
-        String distanceKm,
+        String distanceText,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -31,9 +31,9 @@ public record FindHubRouteResponse(
                 result.destHubName(),
                 result.destHubAddress(),
                 result.durationTime(),
-                result.durationMinutes(),
+                result.durationText(),
                 result.distance(),
-                result.distanceKm(),
+                result.distanceText(),
                 result.createdAt(),
                 result.updatedAt()
         );

--- a/src/main/java/com/fhsh/daitda/hubservice/infrastructure/kakao/client/KakaoDirectionsClient.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/infrastructure/kakao/client/KakaoDirectionsClient.java
@@ -23,6 +23,7 @@ public interface KakaoDirectionsClient {
      */
     record RouteMetrics(
             Integer durationMinutes,
+            long distanceMeters,
             BigDecimal distanceKilometers
     ) {
     }

--- a/src/main/java/com/fhsh/daitda/hubservice/infrastructure/kakao/client/KakaoDirectionsClientImpl.java
+++ b/src/main/java/com/fhsh/daitda/hubservice/infrastructure/kakao/client/KakaoDirectionsClientImpl.java
@@ -68,10 +68,11 @@ public class KakaoDirectionsClientImpl implements KakaoDirectionsClient {
 
             int durationMinutes = Math.max(1, (summary.duration() + 59) / 60);
 
-            BigDecimal distanceKilometers = BigDecimal.valueOf(summary.distance())
+            long distanceMeters = summary.distance().longValue();
+            BigDecimal distanceKilometers = BigDecimal.valueOf(distanceMeters)
                     .divide(BigDecimal.valueOf(1000), 2, RoundingMode.HALF_UP);
 
-            return new RouteMetrics(durationMinutes, distanceKilometers);
+            return new RouteMetrics(durationMinutes, distanceMeters, distanceKilometers);
 
         } catch (BusinessException e) {
             throw e;

--- a/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/HubRouteServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/HubRouteServiceTest.java
@@ -79,6 +79,7 @@ public class HubRouteServiceTest {
                 destHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 95,
+                123_450L,
                 new BigDecimal("123.45")
         ));
 
@@ -209,6 +210,7 @@ public class HubRouteServiceTest {
                 destHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 95,
+                123_450L,
                 new BigDecimal("123.45")
         ));
 
@@ -336,6 +338,7 @@ public class HubRouteServiceTest {
                 destHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 95,
+                123_450L,
                 new BigDecimal("123.45")
         ));
 
@@ -396,6 +399,7 @@ public class HubRouteServiceTest {
                 destHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 77,
+                101_250L,
                 new BigDecimal("101.25")
         ));
 

--- a/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
@@ -61,8 +61,8 @@ public class HubRouteQueryServiceTest {
         assertThat(results.get(0).destHubId()).isEqualTo(DEST_HUB_ID);
         assertThat(results.get(0).srcHubName()).isEqualTo("서울 허브");
         assertThat(results.get(0).destHubName()).isEqualTo("대전 허브");
-        assertThat(results.get(0).durationMinutes()).isEqualTo("120분");
-        assertThat(results.get(0).distanceKm()).isEqualTo("150.00km");
+        assertThat(results.get(0).durationTime()).isEqualTo("120분");
+        assertThat(results.get(0).distanceText()).isEqualTo("150.00km");
     }
 
     @Test

--- a/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
@@ -4,9 +4,11 @@ import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.hubservice.hub.domain.entity.Hub;
 import com.fhsh.daitda.hubservice.hub.domain.repository.HubRepository;
 import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRoutePathResult;
+import com.fhsh.daitda.hubservice.hubroute.application.result.FindHubRouteResult;
 import com.fhsh.daitda.hubservice.hubroute.domain.entity.HubRoute;
 import com.fhsh.daitda.hubservice.hubroute.domain.exception.HubRouteErrorCode;
 import com.fhsh.daitda.hubservice.hubroute.domain.repository.HubRouteRepository;
+import com.fhsh.daitda.hubservice.infrastructure.kakao.client.KakaoDirectionsClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class HubRouteQueryServiceTest {
+class HubRouteQueryServiceTest {
 
     @Mock
     private HubRouteRepository hubRouteRepository;
@@ -34,125 +36,326 @@ public class HubRouteQueryServiceTest {
     @Mock
     private HubRepository hubRepository;
 
+    @Mock
+    private KakaoDirectionsClient kakaoDirectionsClient;
+
     @InjectMocks
     private HubRouteQueryService hubRouteQueryService;
 
-    private static final UUID SRC_HUB_ID = UUID.randomUUID();
-    private static final UUID DEST_HUB_ID = UUID.randomUUID();
-    private static final UUID VIA_HUB_ID = UUID.randomUUID();
     private static final UUID USER_ID = UUID.randomUUID();
 
-    @Test
-    @DisplayName("직행 경로가 200km 미만이면 sequence 1인 1개 리스트 반환")
-    void 직행경로_200km미만_리스트1건반환() {
-        HubRoute directRoute = 생성된경로(SRC_HUB_ID, DEST_HUB_ID, 120, "150.00");
+    private static final UUID SRC_HUB_ID = UUID.randomUUID();
+    private static final UUID DEST_HUB_ID = UUID.randomUUID();
+    private static final UUID RELAY_HUB_ID = UUID.randomUUID();
+    private static final UUID ANOTHER_HUB_ID = UUID.randomUUID();
 
-        stubHub(SRC_HUB_ID, "서울 허브", "서울특별시 송파구 충민로 10");
-        stubHub(DEST_HUB_ID, "대전 허브", "대전광역시 유성구 테크노중앙로 123");
+    @Test
+    @DisplayName("허브 간 경로 조회 시 허브명, 주소, 표시용 시간/거리를 포함한다")
+    void 허브간경로조회_허브상세포함() {
+        // given
+        HubRoute directRoute = 생성된경로(UUID.randomUUID(), SRC_HUB_ID, DEST_HUB_ID, 81, "86.19");
+
+        Hub srcHub = 생성된허브(
+                SRC_HUB_ID,
+                "경기 남부 센터",
+                "경기도 이천시 덕평로 257-21",
+                "127.4230",
+                "37.1896"
+        );
+
+        Hub destHub = 생성된허브(
+                DEST_HUB_ID,
+                "경기 북부 센터",
+                "경기도 고양시 덕양구 권율대로 570",
+                "126.8730",
+                "37.6400"
+        );
 
         when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
                 .thenReturn(Optional.of(directRoute));
+        when(hubRepository.findByHubIdAndDeletedAtIsNull(SRC_HUB_ID))
+                .thenReturn(Optional.of(srcHub));
+        when(hubRepository.findByHubIdAndDeletedAtIsNull(DEST_HUB_ID))
+                .thenReturn(Optional.of(destHub));
 
+        // when
+        FindHubRouteResult result = hubRouteQueryService.searchHubRoute(SRC_HUB_ID, DEST_HUB_ID);
+
+        // then
+        assertThat(result.hubRouteId()).isEqualTo(directRoute.getHubRouteId());
+        assertThat(result.srcHubName()).isEqualTo("경기 남부 센터");
+        assertThat(result.srcHubAddress()).isEqualTo("경기도 이천시 덕평로 257-21");
+        assertThat(result.destHubName()).isEqualTo("경기 북부 센터");
+        assertThat(result.destHubAddress()).isEqualTo("경기도 고양시 덕양구 권율대로 570");
+        assertThat(result.durationTime()).isEqualTo(81);
+        assertThat(result.durationText()).isEqualTo("1시간 21분");
+        assertThat(result.distance()).isEqualByComparingTo("86.19");
+        assertThat(result.distanceText()).isEqualTo("86.19km");
+    }
+
+    @Test
+    @DisplayName("직행 거리가 200km 미만이면 직행 1건을 반환한다")
+    void 최종배송경로조회_직행_200km미만() {
+        // given
+        Hub srcHub = 생성된허브(
+                SRC_HUB_ID,
+                "경기 남부 센터",
+                "경기도 이천시 덕평로 257-21",
+                "127.4230",
+                "37.1896"
+        );
+
+        Hub destHub = 생성된허브(
+                DEST_HUB_ID,
+                "경기 북부 센터",
+                "경기도 고양시 덕양구 권율대로 570",
+                "126.8730",
+                "37.6400"
+        );
+
+        HubRoute directStoredRoute = 생성된경로(UUID.randomUUID(), SRC_HUB_ID, DEST_HUB_ID, 81, "86.19");
+
+        when(hubRepository.findByHubIdAndDeletedAtIsNull(SRC_HUB_ID))
+                .thenReturn(Optional.of(srcHub));
+        when(hubRepository.findByHubIdAndDeletedAtIsNull(DEST_HUB_ID))
+                .thenReturn(Optional.of(destHub));
+
+        when(kakaoDirectionsClient.getDrivingMetrics(
+                srcHub.getLongitude(), srcHub.getLatitude(),
+                destHub.getLongitude(), destHub.getLatitude()
+        )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
+                81,
+                new BigDecimal("86.19")
+        ));
+
+        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
+                .thenReturn(Optional.of(directStoredRoute));
+
+        // when
         List<FindHubRoutePathResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
 
+        // then
         assertThat(results).hasSize(1);
-        assertThat(results.get(0).sequence()).isEqualTo(1);
-        assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
-        assertThat(results.get(0).destHubId()).isEqualTo(DEST_HUB_ID);
-        assertThat(results.get(0).srcHubName()).isEqualTo("서울 허브");
-        assertThat(results.get(0).destHubName()).isEqualTo("대전 허브");
-        assertThat(results.get(0).durationTime()).isEqualTo("120분");
-        assertThat(results.get(0).distanceText()).isEqualTo("150.00km");
+
+        FindHubRoutePathResult result = results.get(0);
+        assertThat(result.sequence()).isEqualTo(1);
+        assertThat(result.hubRouteId()).isEqualTo(directStoredRoute.getHubRouteId());
+        assertThat(result.srcHubId()).isEqualTo(SRC_HUB_ID);
+        assertThat(result.destHubId()).isEqualTo(DEST_HUB_ID);
+        assertThat(result.srcHubName()).isEqualTo("경기 남부 센터");
+        assertThat(result.destHubName()).isEqualTo("경기 북부 센터");
+        assertThat(result.durationTime()).isEqualTo(81);
+        assertThat(result.durationText()).isEqualTo("1시간 21분");
+        assertThat(result.distance()).isEqualByComparingTo("86.19");
+        assertThat(result.distanceText()).isEqualTo("86.19km");
     }
 
     @Test
-    @DisplayName("직행 경로가 200km 이상이면 sequence가 붙은 릴레이 경로 리스트를 반환한다")
-    void 직행경로_200km이상_릴레이경로반환() {
-        HubRoute directRoute = 생성된경로(SRC_HUB_ID, DEST_HUB_ID, 240, "280.00");
-        HubRoute firstRelay = 생성된경로(SRC_HUB_ID, VIA_HUB_ID, 120, "160.00");
-        HubRoute secondRelay = 생성된경로(VIA_HUB_ID, DEST_HUB_ID, 90, "120.00");
+    @DisplayName("직행 거리가 200km 이상이면 relay hub를 선정해 2구간으로 분할한다")
+    void 최종배송경로조회_직행_200km이상_정책분할() {
+        // given
+        Hub srcHub = 생성된허브(
+                SRC_HUB_ID,
+                "대구광역시 센터",
+                "대구 북구 태평로 161",
+                "128.5910",
+                "35.8714"
+        );
 
-        stubHub(SRC_HUB_ID, "서울 허브", "서울특별시 송파구 충민로 10");
-        stubHub(VIA_HUB_ID, "대전 허브", "대전광역시 유성구 테크노중앙로 123");
-        stubHub(DEST_HUB_ID, "대구 허브", "대구광역시 동구 동대구로 456");
+        Hub destHub = 생성된허브(
+                DEST_HUB_ID,
+                "인천광역시 센터",
+                "인천 남동구 정각로 29",
+                "126.7052",
+                "37.4563"
+        );
 
-        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
-                .thenReturn(Optional.of(directRoute));
-        when(hubRouteRepository.findAllByDeletedAtIsNull())
-                .thenReturn(List.of(directRoute, firstRelay, secondRelay));
+        Hub relayHub = 생성된허브(
+                RELAY_HUB_ID,
+                "대전광역시 센터",
+                "대전 서구 둔산로 100",
+                "127.3845",
+                "36.3504"
+        );
 
+        Hub anotherHub = 생성된허브(
+                ANOTHER_HUB_ID,
+                "광주광역시 센터",
+                "광주 서구 내방로 111",
+                "126.8514",
+                "35.1595"
+        );
+
+        HubRoute firstStoredRoute = 생성된경로(UUID.randomUUID(), SRC_HUB_ID, RELAY_HUB_ID, 125, "151.76");
+        HubRoute secondStoredRoute = 생성된경로(UUID.randomUUID(), RELAY_HUB_ID, DEST_HUB_ID, 153, "173.65");
+
+        when(hubRepository.findByHubIdAndDeletedAtIsNull(SRC_HUB_ID))
+                .thenReturn(Optional.of(srcHub));
+        when(hubRepository.findByHubIdAndDeletedAtIsNull(DEST_HUB_ID))
+                .thenReturn(Optional.of(destHub));
+        when(hubRepository.findAllByDeletedAtIsNull())
+                .thenReturn(List.of(srcHub, destHub, relayHub, anotherHub));
+
+        // 직행은 200km 이상
+        when(kakaoDirectionsClient.getDrivingMetrics(
+                srcHub.getLongitude(), srcHub.getLatitude(),
+                destHub.getLongitude(), destHub.getLatitude()
+        )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
+                227,
+                new BigDecimal("299.74")
+        ));
+
+        // relayHub 후보: 두 구간 모두 200km 미만
+        when(kakaoDirectionsClient.getDrivingMetrics(
+                srcHub.getLongitude(), srcHub.getLatitude(),
+                relayHub.getLongitude(), relayHub.getLatitude()
+        )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
+                125,
+                new BigDecimal("151.76")
+        ));
+        when(kakaoDirectionsClient.getDrivingMetrics(
+                relayHub.getLongitude(), relayHub.getLatitude(),
+                destHub.getLongitude(), destHub.getLatitude()
+        )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
+                153,
+                new BigDecimal("173.65")
+        ));
+
+        // anotherHub 후보: 유효하지만 총 거리가 더 김
+        when(kakaoDirectionsClient.getDrivingMetrics(
+                srcHub.getLongitude(), srcHub.getLatitude(),
+                anotherHub.getLongitude(), anotherHub.getLatitude()
+        )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
+                150,
+                new BigDecimal("180.00")
+        ));
+        when(kakaoDirectionsClient.getDrivingMetrics(
+                anotherHub.getLongitude(), anotherHub.getLatitude(),
+                destHub.getLongitude(), destHub.getLatitude()
+        )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
+                165,
+                new BigDecimal("190.00")
+        ));
+
+        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, RELAY_HUB_ID))
+                .thenReturn(Optional.of(firstStoredRoute));
+        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(RELAY_HUB_ID, DEST_HUB_ID))
+                .thenReturn(Optional.of(secondStoredRoute));
+
+        // when
         List<FindHubRoutePathResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
 
+        // then
         assertThat(results).hasSize(2);
 
-        assertThat(results.get(0).sequence()).isEqualTo(1);
-        assertThat(results.get(0).srcHubId()).isEqualTo(SRC_HUB_ID);
-        assertThat(results.get(0).destHubId()).isEqualTo(VIA_HUB_ID);
-        assertThat(results.get(0).srcHubName()).isEqualTo("서울 허브");
-        assertThat(results.get(0).destHubName()).isEqualTo("대전 허브");
+        FindHubRoutePathResult first = results.get(0);
+        assertThat(first.sequence()).isEqualTo(1);
+        assertThat(first.hubRouteId()).isEqualTo(firstStoredRoute.getHubRouteId());
+        assertThat(first.srcHubId()).isEqualTo(SRC_HUB_ID);
+        assertThat(first.destHubId()).isEqualTo(RELAY_HUB_ID);
+        assertThat(first.srcHubName()).isEqualTo("대구광역시 센터");
+        assertThat(first.destHubName()).isEqualTo("대전광역시 센터");
+        assertThat(first.durationText()).isEqualTo("2시간 5분");
+        assertThat(first.distanceText()).isEqualTo("151.76km");
 
-        assertThat(results.get(1).sequence()).isEqualTo(2);
-        assertThat(results.get(1).srcHubId()).isEqualTo(VIA_HUB_ID);
-        assertThat(results.get(1).destHubId()).isEqualTo(DEST_HUB_ID);
-        assertThat(results.get(1).srcHubName()).isEqualTo("대전 허브");
-        assertThat(results.get(1).destHubName()).isEqualTo("대구 허브");
+        FindHubRoutePathResult second = results.get(1);
+        assertThat(second.sequence()).isEqualTo(2);
+        assertThat(second.hubRouteId()).isEqualTo(secondStoredRoute.getHubRouteId());
+        assertThat(second.srcHubId()).isEqualTo(RELAY_HUB_ID);
+        assertThat(second.destHubId()).isEqualTo(DEST_HUB_ID);
+        assertThat(second.srcHubName()).isEqualTo("대전광역시 센터");
+        assertThat(second.destHubName()).isEqualTo("인천광역시 센터");
+        assertThat(second.durationText()).isEqualTo("2시간 33분");
+        assertThat(second.distanceText()).isEqualTo("173.65km");
     }
 
     @Test
-    @DisplayName("직행 경로가 없더라도 릴레이 경로가 있으면 sequence가 붙은 리스트를 반환한다")
-    void 직행경로없음_릴레이경로반환() {
-        HubRoute firstRelay = 생성된경로(SRC_HUB_ID, VIA_HUB_ID, 120, "160.00");
-        HubRoute secondRelay = 생성된경로(VIA_HUB_ID, DEST_HUB_ID, 90, "120.00");
+    @DisplayName("직행 거리가 200km 이상이어도 유효한 relay hub가 없으면 예외가 발생한다")
+    void 최종배송경로조회_relay후보없음_예외() {
+        // given
+        Hub srcHub = 생성된허브(
+                SRC_HUB_ID,
+                "대구광역시 센터",
+                "대구 북구 태평로 161",
+                "128.5910",
+                "35.8714"
+        );
 
-        stubHub(SRC_HUB_ID, "서울 허브", "서울특별시 송파구 충민로 10");
-        stubHub(VIA_HUB_ID, "대전 허브", "대전광역시 유성구 테크노중앙로 123");
-        stubHub(DEST_HUB_ID, "대구 허브", "대구광역시 동구 동대구로 456");
+        Hub destHub = 생성된허브(
+                DEST_HUB_ID,
+                "인천광역시 센터",
+                "인천 남동구 정각로 29",
+                "126.7052",
+                "37.4563"
+        );
 
-        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
-                .thenReturn(Optional.empty());
-        when(hubRouteRepository.findAllByDeletedAtIsNull())
-                .thenReturn(List.of(firstRelay, secondRelay));
+        Hub relayHub = 생성된허브(
+                RELAY_HUB_ID,
+                "광주광역시 센터",
+                "광주 서구 내방로 111",
+                "126.8514",
+                "35.1595"
+        );
 
-        List<FindHubRoutePathResult> results = hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID);
+        when(hubRepository.findByHubIdAndDeletedAtIsNull(SRC_HUB_ID))
+                .thenReturn(Optional.of(srcHub));
+        when(hubRepository.findByHubIdAndDeletedAtIsNull(DEST_HUB_ID))
+                .thenReturn(Optional.of(destHub));
+        when(hubRepository.findAllByDeletedAtIsNull())
+                .thenReturn(List.of(srcHub, destHub, relayHub));
 
-        assertThat(results).hasSize(2);
-        assertThat(results.get(0).sequence()).isEqualTo(1);
-        assertThat(results.get(1).sequence()).isEqualTo(2);
-    }
+        // 직행은 200km 이상
+        when(kakaoDirectionsClient.getDrivingMetrics(
+                srcHub.getLongitude(), srcHub.getLatitude(),
+                destHub.getLongitude(), destHub.getLatitude()
+        )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
+                227,
+                new BigDecimal("299.74")
+        ));
 
-    @Test
-    @DisplayName("출발 허브와 도착 허브가 같으면 예외 발생")
-    void 출발도착허브동일_예외() {
-        assertThatThrownBy(() -> hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, SRC_HUB_ID))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("출발 허브와 도착 허브는 같을 수 없습니다.");
-    }
+        // relay 후보가 한 구간이라도 200km 이상이라 탈락
+        when(kakaoDirectionsClient.getDrivingMetrics(
+                srcHub.getLongitude(), srcHub.getLatitude(),
+                relayHub.getLongitude(), relayHub.getLatitude()
+        )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
+                170,
+                new BigDecimal("210.00")
+        ));
+        when(kakaoDirectionsClient.getDrivingMetrics(
+                relayHub.getLongitude(), relayHub.getLatitude(),
+                destHub.getLongitude(), destHub.getLatitude()
+        )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
+                120,
+                new BigDecimal("150.00")
+        ));
 
-    @Test
-    @DisplayName("직행도 없고 릴레이 경로도 없으면 예외가 발생")
-    void 경로없음_예외() {
-        when(hubRouteRepository.findBySrcHubIdAndDestHubIdAndDeletedAtIsNull(SRC_HUB_ID, DEST_HUB_ID))
-                .thenReturn(Optional.empty());
-        when(hubRouteRepository.findAllByDeletedAtIsNull())
-                .thenReturn(List.of());
-
+        // when & then
         assertThatThrownBy(() -> hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, DEST_HUB_ID))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND);
     }
 
-    private void stubHub(UUID hubId, String hubName, String hubAddress) {
-        when(hubRepository.findByHubIdAndDeletedAtIsNull(hubId))
-                .thenReturn(Optional.of(생성된허브(hubId, hubName, hubAddress)));
+    @Test
+    @DisplayName("출발 허브와 도착 허브가 같으면 예외가 발생한다")
+    void 최종배송경로조회_같은허브_예외() {
+        assertThatThrownBy(() -> hubRouteQueryService.getHubRoutePath(SRC_HUB_ID, SRC_HUB_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("출발 허브와 도착 허브는 같을 수 없습니다.");
     }
 
-    private Hub 생성된허브(UUID hubId, String hubName, String hubAddress) {
+    private Hub 생성된허브(
+            UUID hubId,
+            String hubName,
+            String hubAddress,
+            String longitude,
+            String latitude
+    ) {
         Hub hub = Hub.create(
                 hubName,
                 hubAddress,
-                new BigDecimal("127.100000"),
-                new BigDecimal("37.514000"),
+                new BigDecimal(longitude),
+                new BigDecimal(latitude),
                 false,
                 USER_ID
         );
@@ -162,7 +365,13 @@ public class HubRouteQueryServiceTest {
         return hub;
     }
 
-    private HubRoute 생성된경로(UUID srcHubId, UUID destHubId, Integer durationTime, String distance) {
+    private HubRoute 생성된경로(
+            UUID hubRouteId,
+            UUID srcHubId,
+            UUID destHubId,
+            Integer durationTime,
+            String distance
+    ) {
         HubRoute hubRoute = HubRoute.create(
                 srcHubId,
                 destHubId,
@@ -172,7 +381,9 @@ public class HubRouteQueryServiceTest {
         );
 
         ReflectionTestUtils.invokeMethod(hubRoute, "prePersist");
+        ReflectionTestUtils.setField(hubRoute, "hubRouteId", hubRouteId);
         ReflectionTestUtils.setField(hubRoute, "createdAt", LocalDateTime.now());
+        ReflectionTestUtils.setField(hubRoute, "updatedAt", LocalDateTime.now());
         return hubRoute;
     }
 }

--- a/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/hubservice/hubroute/application/service/query/HubRouteQueryServiceTest.java
@@ -125,6 +125,7 @@ class HubRouteQueryServiceTest {
                 destHub.getLongitude(), destHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 81,
+                86_190L,
                 new BigDecimal("86.19")
         ));
 
@@ -202,6 +203,7 @@ class HubRouteQueryServiceTest {
                 destHub.getLongitude(), destHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 227,
+                299_740L,
                 new BigDecimal("299.74")
         ));
 
@@ -211,6 +213,7 @@ class HubRouteQueryServiceTest {
                 relayHub.getLongitude(), relayHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 125,
+                151_760L,
                 new BigDecimal("151.76")
         ));
         when(kakaoDirectionsClient.getDrivingMetrics(
@@ -218,6 +221,7 @@ class HubRouteQueryServiceTest {
                 destHub.getLongitude(), destHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 153,
+                173_650L,
                 new BigDecimal("173.65")
         ));
 
@@ -227,6 +231,7 @@ class HubRouteQueryServiceTest {
                 anotherHub.getLongitude(), anotherHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 150,
+                180_000L,
                 new BigDecimal("180.00")
         ));
         when(kakaoDirectionsClient.getDrivingMetrics(
@@ -234,6 +239,7 @@ class HubRouteQueryServiceTest {
                 destHub.getLongitude(), destHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 165,
+                190_000L,
                 new BigDecimal("190.00")
         ));
 
@@ -310,6 +316,7 @@ class HubRouteQueryServiceTest {
                 destHub.getLongitude(), destHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 227,
+                299_740L,
                 new BigDecimal("299.74")
         ));
 
@@ -319,6 +326,7 @@ class HubRouteQueryServiceTest {
                 relayHub.getLongitude(), relayHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 170,
+                210_000L,
                 new BigDecimal("210.00")
         ));
         when(kakaoDirectionsClient.getDrivingMetrics(
@@ -326,6 +334,7 @@ class HubRouteQueryServiceTest {
                 destHub.getLongitude(), destHub.getLatitude()
         )).thenReturn(new KakaoDirectionsClient.RouteMetrics(
                 120,
+                150_000L,
                 new BigDecimal("150.00")
         ));
 


### PR DESCRIPTION
## 🌱 설명

최종 배송 경로 조회 로직을 개선

기존에는 저장된 `hub_route` 데이터를 그래프처럼 이어 붙여 최종 경로를 조회하는 방식이었지만
발제문 요구사항에 맞게 **직행 거리 200km 기준으로 정책 기반 경유지 분할 방식**을 적용하도록 리팩토링했습니다

추가로 허브 경로 응답에 허브명/허브 주소/표시용 시간·거리 문자열을 포함하도록 확장
최종 배송 경로 조회 응답은 path 전용 DTO로 분리하여 `sequence`를 포함하도록 정리했습니다

> `/internal/v1/hub-routes` 는 등록된 허브 간 이동정보 단건 조회 용도로 유지 
> `/internal/v1/hub-routes/path` 는 최종 배송 예상 경로 계산 조회 용도로 사용합니다

## 📌 관련 이슈

- close #31 

## ✅ 주요 변경 사항

- 최종 배송 경로 조회(`/internal/v1/hub-routes/path`) 로직 리팩토링
  - 직행 거리 200km 미만: 직행 1건 리스트 반환
  - 직행 거리 200km 이상: 중간 경유 허브를 정책적으로 선정하여 2구간으로 분할 반환
- 기존 그래프 기반 `findRelayPath()` 방식에서 정책 기반 경유지 선정 방식으로 개선
- `selectRelayHub()` 추가
  - 활성 허브 후보 중 출발/도착 허브를 제외하고
  - `[출발 -> 후보]`, `[후보 -> 도착]` 두 구간 모두 200km 미만인 후보만 유효 처리
  - 총 거리 합이 가장 짧은 허브를 중간 경유 허브로 선택
- 허브 경로 응답 확장
  - `srcHubName`
  - `srcHubAddress`
  - `destHubName`
  - `destHubAddress`
  - `durationText`
  - `distanceText`
- 소요시간 표시 포맷 개선
  - 60분 이하: `N분`
  - 60분 초과: `N시간 M분`
- 최종 배송 경로 조회 응답을 path 전용 DTO로 분리
  - `sequence` 추가
  - 계산은 되었지만 등록되지 않은 구간은 `hubRouteId = null` 허용
- `/internal/v1/hub-routes` 단건 조회 API는 유지
  - 등록된 허브 간 이동정보 단건 조회 용도
- 테스트 코드 수정 및 추가
  - 직행 200km 미만
  - 직행 200km 이상
  - relay 후보 없음 예외
  - 응답 필드 검증

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- `/internal/v1/hub-routes/path` 는 단순 등록 정보 조회가 아니라 **최종 배송 예상 경로 계산 조회** 성격을 가집니다
- 따라서 계산된 구간이 허브 간 이동정보로 등록되지 않은 경우 `hubRouteId` 는 `null` 일 수 있습니다
- 반면 `/internal/v1/hub-routes` 는 등록된 허브 간 이동정보를 단건 조회하는 내부 API로 유지했습니다
- 이번 변경으로 발제문에 나온 “200km 이상이면 중간 경유지를 통해 배송” 요구사항을 코드 구조에 맞게 반영했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 개선사항

* **기능 개선**
  * 거리와 소요 시간이 더 읽기 쉬운 텍스트 형식(예: "N분", "H시간 M분", "X.XXkm")으로 표시됩니다.
  * 경로 검색이 실시간 주행 거리 기준으로 직행 또는 환승 허브를 결정해 보다 현실적인 경로를 제공합니다.
* **응답 변경**
  * API 응답의 거리/소요 시간 필드명이 사용자 친화적 텍스트로 변경되었습니다.
* **테스트**
  * 다양한 주행 시나리오를 반영한 테스트가 추가·보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->